### PR TITLE
Update libmctp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ add_definitions (-DMCTP_HAVE_FILEIO)
 add_definitions (-DMCTP_HAVE_STDIO)
 add_definitions (-DMCTP_DEFAULT_ALLOC)
 
-add_library (mctp STATIC alloc.c astlpc.c crc32.c core.c log.c libmctp.h serial.c crc-16-ccitt.c)
+add_library (mctp STATIC alloc.c astlpc.c crc32.c core.c log.c libmctp.h serial.c crc-16-ccitt.c control.c)
 
 target_include_directories (mctp PUBLIC
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ ACLOCAL_AMFLAGS = -I m4
 lib_LTLIBRARIES = libmctp.la
 libmctp_la_SOURCES = core.c alloc.c log.c \
 		     libmctp-alloc.h libmctp-log.h \
-		     libmctp-cmds.h
+		     libmctp-cmds.h control.c
 include_HEADERS = libmctp.h
 
 if LIBMCTP_BINDING_serial

--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ This library is intended to be a portable implementation of the Management
 Component Transport Protocol (MCTP), as defined by DMTF standard "DSP0236", plus
 transport binding specifications.
 
+## Target usage
+
+`libmctp` is a library that implements a straightforward MCTP stack. It will be
+useful in a two main scenarios:
+
+- where you are implementing MCTP in an embedded device; or
+- where you have Linux system:
+  - with no kernel MCTP support,
+  - need a single application implementing all of the MCTP stack; and
+  - you are providing your own hardware drivers for MCTP transports.
+
+Notably, if you are implementing an MCTP application on Linux, you _almost
+certainly_ want to use the in-kernel MCTP support, which gives you a standard
+sockets-based interface to transmit and receive MCTP messages. When using the
+Linux kernel MCTP support, you do not need to use `libmctp` at all, and can use
+the sockets directly. `libmctp` does not provide functions to interact with the
+kernel MCTP sockets.
+
+There is an overview and example code for the in-kernel support in the [MCTP
+kernel docs][kernel-mctp], and a general guide in an [introduction to MCTP on
+Linux][mctp-linux-intro] document.
+
+[kernel-mctp]: https://docs.kernel.org/networking/mctp.html
+[mctp-linux-intro]:
+  https://codeconstruct.com.au/docs/mctp-on-linux-introduction/
+
 ## Contact
 
 - Email: See [OWNERS](OWNERS). Please also Cc <openbmc@lists.ozlabs.org>

--- a/astlpc.c
+++ b/astlpc.c
@@ -1401,7 +1401,8 @@ static int mctp_astlpc_init_fileio_lpc(struct mctp_binding_astlpc *astlpc)
 		astlpc_prwarn(astlpc, "LPC mmap failed");
 		rc = -1;
 	} else {
-		astlpc->lpc_map = lpc_map_base + map.size - LPC_WIN_SIZE;
+		astlpc->lpc_map =
+			(uint8_t *)lpc_map_base + map.size - LPC_WIN_SIZE;
 	}
 
 	close(fd);

--- a/astlpc.c
+++ b/astlpc.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <assert.h>
-#include <err.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/astlpc.c
+++ b/astlpc.c
@@ -170,7 +170,7 @@ struct mctp_binding_astlpc {
 /* clang-format on */
 
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #endif
 
 static uint32_t astlpc_packet_size_v1(uint32_t body)

--- a/container_of.h
+++ b/container_of.h
@@ -3,7 +3,7 @@
 
 #ifndef container_of
 #define container_of(ptr, type, member)                                        \
-	(type *)((char *)(ptr) - (char *)&((type *)0)->member)
+	(type *)((char *)(ptr) - offsetof(type, member))
 #endif
 
 #endif

--- a/control.c
+++ b/control.c
@@ -1,0 +1,309 @@
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "libmctp-cmds.h"
+#include "libmctp-alloc.h"
+#include "libmctp-log.h"
+#include "core-internal.h"
+
+#include "control.h"
+
+static void fill_resp(const void *req, struct mctp_ctrl_msg_hdr *hdr)
+{
+	const struct mctp_ctrl_msg_hdr *req_hdr = req;
+	hdr->ic_msg_type = MCTP_CTRL_HDR_MSG_TYPE;
+	hdr->rq_dgram_inst = req_hdr->rq_dgram_inst &
+			     MCTP_CTRL_HDR_INSTANCE_ID_MASK;
+	hdr->command_code = req_hdr->command_code;
+}
+
+static uint8_t mctp_ctrl_set_endpoint_id(struct mctp_bus *bus, uint8_t src_eid,
+					 uint8_t msg_tag, const void *data,
+					 size_t len)
+{
+	if (len != sizeof(struct mctp_ctrl_cmd_set_endpoint_id_req)) {
+		return MCTP_CTRL_CC_ERROR_INVALID_LENGTH;
+	}
+	const struct mctp_ctrl_cmd_set_endpoint_id_req *req = data;
+
+	uint8_t op = req->operation & MCTP_CTRL_SET_EID_OP_MASK;
+	if (!(op == MCTP_CTRL_SET_EID_OP_SET ||
+	      op == MCTP_CTRL_SET_EID_OP_FORCE)) {
+		return MCTP_CTRL_CC_ERROR_INVALID_DATA;
+	}
+
+	if (mctp_bus_set_eid(bus->binding, req->eid)) {
+		return MCTP_CTRL_CC_ERROR_INVALID_DATA;
+	}
+
+	struct mctp_ctrl_cmd_set_endpoint_id_resp *resp =
+		__mctp_msg_alloc(sizeof(*resp), bus->mctp);
+	if (!resp) {
+		mctp_prdebug("no response buffer");
+		return MCTP_CTRL_CC_ERROR;
+	}
+	memset(resp, 0x00, sizeof(*resp));
+	fill_resp(data, &resp->hdr);
+	resp->completion_code = MCTP_CTRL_CC_SUCCESS;
+	resp->status = MCTP_CTRL_SET_EID_STATUS_ACCEPTED;
+	resp->eid = req->eid;
+	resp->pool_size = 0;
+
+	int rc = mctp_message_tx_alloced(bus->mctp, src_eid, false, msg_tag,
+					 resp, sizeof(*resp));
+	if (!rc) {
+		mctp_prdebug("set_endpoint_id response send failed: %d", rc);
+	}
+	return MCTP_CTRL_CC_SUCCESS;
+}
+
+static uint8_t mctp_ctrl_get_endpoint_id(struct mctp_bus *bus, uint8_t src_eid,
+					 uint8_t msg_tag, const void *data,
+					 size_t len)
+{
+	if (len != sizeof(struct mctp_ctrl_msg_hdr)) {
+		/* Expect empty request */
+		return MCTP_CTRL_CC_ERROR_INVALID_LENGTH;
+	}
+	(void)data;
+
+	struct mctp_ctrl_cmd_get_endpoint_id_resp *resp =
+		__mctp_msg_alloc(sizeof(*resp), bus->mctp);
+	if (!resp) {
+		mctp_prdebug("no response buffer");
+		return MCTP_CTRL_CC_ERROR;
+	}
+	memset(resp, 0x00, sizeof(*resp));
+	fill_resp(data, &resp->hdr);
+	resp->completion_code = MCTP_CTRL_CC_SUCCESS;
+	resp->endpoint_id = bus->eid;
+	resp->endpoint_type = MCTP_CTRL_ENDPOINT_TYPE_SIMPLE |
+			      MCTP_CTRL_ENDPOINT_ID_TYPE_STATIC;
+	resp->medium_specific = 0x00;
+
+	int rc = mctp_message_tx_alloced(bus->mctp, src_eid, false, msg_tag,
+					 resp, sizeof(*resp));
+	if (!rc) {
+		mctp_prdebug("get_endpoint_id response send failed: %d", rc);
+	}
+	return MCTP_CTRL_CC_SUCCESS;
+}
+
+#define MCTP_PROTOCOL_COUNT 4
+/* Big endian */
+const uint8_t MCTP_PROTOCOL_VERSIONS[MCTP_PROTOCOL_COUNT * 4] = {
+	// 1.0
+	0xf1,
+	0xf0,
+	0xff,
+	0x00,
+	// 1.1
+	0xf1,
+	0xf1,
+	0xff,
+	0x00,
+	// 1.2
+	0xf1,
+	0xf2,
+	0xff,
+	0x00,
+	// 1.3.3
+	0xf1,
+	0xf3,
+	0xf3,
+	0x00,
+};
+
+static uint8_t mctp_ctrl_get_version(struct mctp_bus *bus, uint8_t src_eid,
+				     uint8_t msg_tag, const void *data,
+				     size_t len)
+{
+	if (len != sizeof(struct mctp_ctrl_cmd_get_version_req)) {
+		return MCTP_CTRL_CC_ERROR_INVALID_LENGTH;
+	}
+	const struct mctp_ctrl_cmd_get_version_req *req = data;
+
+	switch (req->msg_type) {
+	case 0x00:
+	case 0xff:
+		/* Only have versions for MCTP base or control */
+		break;
+	default:
+		return MCTP_CTRL_VERSIONS_NOT_SUPPORTED;
+	}
+
+	/* Return only the versions for MCTP */
+	size_t total_sz = sizeof(struct mctp_ctrl_cmd_get_version_resp) +
+			  sizeof(MCTP_PROTOCOL_VERSIONS);
+
+	struct mctp_ctrl_cmd_get_version_resp *resp =
+		__mctp_msg_alloc(total_sz, bus->mctp);
+	if (!resp) {
+		mctp_prdebug("no response buffer");
+		return MCTP_CTRL_CC_ERROR;
+	}
+	memset(resp, 0x00, total_sz);
+	fill_resp(data, &resp->hdr);
+	resp->completion_code = MCTP_CTRL_CC_SUCCESS;
+	resp->version_count = MCTP_PROTOCOL_COUNT;
+	memcpy(resp->versions, MCTP_PROTOCOL_VERSIONS,
+	       sizeof(MCTP_PROTOCOL_VERSIONS));
+
+	int rc = mctp_message_tx_alloced(bus->mctp, src_eid, false, msg_tag,
+					 resp, total_sz);
+	if (!rc) {
+		mctp_prdebug("mctp get_version response send failed: %d", rc);
+	}
+	return MCTP_CTRL_CC_SUCCESS;
+}
+
+static uint8_t mctp_ctrl_get_types(struct mctp_bus *bus, uint8_t src_eid,
+				   uint8_t msg_tag, const void *data,
+				   size_t len)
+{
+	if (len != sizeof(struct mctp_ctrl_msg_hdr)) {
+		return MCTP_CTRL_CC_ERROR_INVALID_LENGTH;
+	}
+	(void)data;
+
+	size_t total_sz = sizeof(struct mctp_ctrl_cmd_get_types_resp) +
+			  bus->mctp->control.num_msg_types;
+
+	struct mctp_ctrl_cmd_get_types_resp *resp =
+		__mctp_msg_alloc(total_sz, bus->mctp);
+	if (!resp) {
+		mctp_prdebug("no response buffer");
+		return MCTP_CTRL_CC_ERROR;
+	}
+	memset(resp, 0x00, total_sz);
+	fill_resp(data, &resp->hdr);
+	resp->completion_code = MCTP_CTRL_CC_SUCCESS;
+	resp->type_count = bus->mctp->control.num_msg_types;
+	memcpy(resp->types, bus->mctp->control.msg_types,
+	       bus->mctp->control.num_msg_types);
+
+	int rc = mctp_message_tx_alloced(bus->mctp, src_eid, false, msg_tag,
+					 resp, total_sz);
+	if (!rc) {
+		mctp_prdebug("mctp get_types response send failed: %d", rc);
+	}
+	return MCTP_CTRL_CC_SUCCESS;
+}
+
+static void reply_error(struct mctp *mctp, uint8_t src_eid, uint8_t msg_tag,
+			const struct mctp_ctrl_msg_hdr *ctrl_hdr, uint8_t ccode)
+{
+	struct mctp_ctrl_cmd_empty_resp *resp =
+		__mctp_msg_alloc(sizeof(*resp), mctp);
+	if (!resp) {
+		mctp_prdebug("no response buffer");
+		return;
+	}
+	memset(resp, 0x00, sizeof(*resp));
+	fill_resp(ctrl_hdr, &resp->hdr);
+	resp->completion_code = ccode;
+
+	int rc = mctp_message_tx_alloced(mctp, src_eid, false, msg_tag, resp,
+					 sizeof(*resp));
+	if (!rc) {
+		mctp_prdebug("error response send failed: %d", rc);
+	}
+}
+
+/* Control message request handler. This will respond to the mandatory MCTP control
+ * commands */
+bool mctp_control_handler(struct mctp_bus *bus, mctp_eid_t src_eid,
+			  bool tag_owner, uint8_t msg_tag, const void *data,
+			  size_t len)
+{
+	if (!tag_owner) {
+		// Not a request
+		return false;
+	}
+
+	if (len < 1) {
+		// No type byte
+		return false;
+	}
+
+	const struct mctp_ctrl_msg_hdr *ctrl_hdr = data;
+	if (ctrl_hdr->ic_msg_type != MCTP_CTRL_HDR_MSG_TYPE) {
+		// Not Control type
+		return false;
+	}
+
+	if (len < sizeof(struct mctp_ctrl_msg_hdr)) {
+		// Drop short messages, but treat as handled
+		return true;
+	}
+
+	if ((ctrl_hdr->rq_dgram_inst &
+	     (MCTP_CTRL_HDR_FLAG_REQUEST | MCTP_CTRL_HDR_FLAG_DGRAM)) !=
+	    MCTP_CTRL_HDR_FLAG_REQUEST) {
+		// Drop message, isn't a request.
+		// Treat as handled since TO bit was set.
+		return true;
+	}
+
+	// A valid MCTP Control request has been received, process it
+
+	uint8_t cc = MCTP_CTRL_CC_ERROR_UNSUPPORTED_CMD;
+	switch (ctrl_hdr->command_code) {
+	case MCTP_CTRL_CMD_SET_ENDPOINT_ID:
+		cc = mctp_ctrl_set_endpoint_id(bus, src_eid, msg_tag, data,
+					       len);
+		break;
+	case MCTP_CTRL_CMD_GET_ENDPOINT_ID:
+		cc = mctp_ctrl_get_endpoint_id(bus, src_eid, msg_tag, data,
+					       len);
+		break;
+	case MCTP_CTRL_CMD_GET_VERSION_SUPPORT:
+		cc = mctp_ctrl_get_version(bus, src_eid, msg_tag, data, len);
+		break;
+	case MCTP_CTRL_CMD_GET_MESSAGE_TYPE_SUPPORT:
+		cc = mctp_ctrl_get_types(bus, src_eid, msg_tag, data, len);
+		break;
+	default:
+		cc = MCTP_CTRL_CC_ERROR_UNSUPPORTED_CMD;
+		break;
+	}
+
+	if (cc) {
+		reply_error(bus->mctp, src_eid, msg_tag, ctrl_hdr, cc);
+	}
+
+	// No further handling required.
+	return true;
+}
+
+int mctp_control_add_type(struct mctp *mctp, uint8_t msg_type)
+{
+	/* Check for existing */
+	for (size_t i = 0; i < mctp->control.num_msg_types; i++) {
+		if (mctp->control.msg_types[i] == msg_type) {
+			return 0;
+		}
+	}
+
+	if (mctp->control.num_msg_types == MCTP_CONTROL_MAX_TYPES) {
+		return -ENOSPC;
+	}
+
+	mctp->control.msg_types[mctp->control.num_msg_types] = msg_type;
+	mctp->control.num_msg_types++;
+	return 0;
+}
+
+void mctp_control_remove_type(struct mctp *mctp, uint8_t msg_type)
+{
+	for (size_t i = 0; i < mctp->control.num_msg_types; i++) {
+		if (mctp->control.msg_types[i] == msg_type) {
+			memmove(&mctp->control.msg_types[i],
+				&mctp->control.msg_types[i + 1],
+				mctp->control.num_msg_types - (i + 1));
+			mctp->control.num_msg_types--;
+		}
+	}
+}

--- a/control.h
+++ b/control.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "libmctp.h"
+
+/* Handle a MCTP control message. Returns true for control requests,
+ * false otherwise */
+bool mctp_control_handler(struct mctp_bus *bus, uint8_t src_eid, bool tag_owner,
+			  uint8_t msg_tag, const void *data, size_t len);

--- a/core-internal.h
+++ b/core-internal.h
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
+#pragma once
+
+#include "libmctp.h"
+
+/* 64kb should be sufficient for a single message. Applications
+ * requiring higher sizes can override by setting max_message_size.*/
+#ifndef MCTP_MAX_MESSAGE_SIZE
+#define MCTP_MAX_MESSAGE_SIZE 65536
+#endif
+
+/* Must be >= 2 for bridge busses */
+#ifndef MCTP_MAX_BUSSES
+#define MCTP_MAX_BUSSES 2
+#endif
+
+/* Concurrent reassembly contexts. */
+#ifndef MCTP_REASSEMBLY_CTXS
+#define MCTP_REASSEMBLY_CTXS 16
+#endif
+
+/* Outbound request tags */
+#ifndef MCTP_REQ_TAGS
+#define MCTP_REQ_TAGS MCTP_REASSEMBLY_CTXS
+#endif
+
+/* Internal data structures */
+
+enum mctp_bus_state {
+	mctp_bus_state_constructed = 0,
+	mctp_bus_state_tx_enabled,
+	mctp_bus_state_tx_disabled,
+};
+
+struct mctp_bus {
+	mctp_eid_t eid;
+	struct mctp_binding *binding;
+	enum mctp_bus_state state;
+	struct mctp *mctp;
+
+	/* Current message to transmit */
+	void *tx_msg;
+	/* Position in tx_msg */
+	size_t tx_msgpos;
+	/* Length of tx_msg */
+	size_t tx_msglen;
+	/* Length of current packet payload */
+	size_t tx_pktlen;
+	uint8_t tx_seq;
+	uint8_t tx_src;
+	uint8_t tx_dest;
+	bool tx_to;
+	uint8_t tx_tag;
+
+	/* todo: routing */
+};
+
+struct mctp_msg_ctx {
+	/* NULL buf indicates an unused mctp_msg_ctx */
+	void *buf;
+
+	uint8_t src;
+	uint8_t dest;
+	uint8_t tag;
+	uint8_t last_seq;
+	size_t buf_size;
+	size_t buf_alloc_size;
+	size_t fragment_size;
+};
+
+struct mctp_req_tag {
+	/* 0 is an unused entry */
+	mctp_eid_t local;
+	mctp_eid_t remote;
+	uint8_t tag;
+};
+
+struct mctp {
+	int n_busses;
+	struct mctp_bus busses[MCTP_MAX_BUSSES];
+
+	/* Message RX callback */
+	mctp_rx_fn message_rx;
+	void *message_rx_data;
+
+	/* Packet capture callback */
+	mctp_capture_fn capture;
+	void *capture_data;
+
+	/* Message reassembly. */
+	struct mctp_msg_ctx msg_ctxs[MCTP_REASSEMBLY_CTXS];
+
+	/* Allocated outbound TO tags */
+	struct mctp_req_tag req_tags[MCTP_REQ_TAGS];
+	/* used to avoid always allocating tag 0 */
+	uint8_t tag_round_robin;
+
+	enum {
+		ROUTE_ENDPOINT,
+		ROUTE_BRIDGE,
+	} route_policy;
+	size_t max_message_size;
+
+	void *alloc_ctx;
+};

--- a/core-internal.h
+++ b/core-internal.h
@@ -24,6 +24,13 @@
 #define MCTP_REQ_TAGS MCTP_REASSEMBLY_CTXS
 #endif
 
+#ifndef MCTP_DEFAULT_CLOCK_GETTIME
+#define MCTP_DEFAULT_CLOCK_GETTIME 1
+#endif
+
+/* Tag expiry timeout, in milliseconds */
+static const uint64_t MCTP_TAG_TIMEOUT = 6000;
+
 /* Internal data structures */
 
 enum mctp_bus_state {
@@ -73,6 +80,8 @@ struct mctp_req_tag {
 	mctp_eid_t local;
 	mctp_eid_t remote;
 	uint8_t tag;
+	/* time of tag expiry */
+	uint64_t expiry;
 };
 
 struct mctp {
@@ -102,4 +111,7 @@ struct mctp {
 	size_t max_message_size;
 
 	void *alloc_ctx;
+
+	uint64_t (*platform_now)(void *);
+	void *platform_now_ctx;
 };

--- a/core-internal.h
+++ b/core-internal.h
@@ -28,6 +28,10 @@
 #define MCTP_DEFAULT_CLOCK_GETTIME 1
 #endif
 
+#ifndef MCTP_CONTROL_HANDLER
+#define MCTP_CONTROL_HANDLER 1
+#endif
+
 /* Tag expiry timeout, in milliseconds */
 static const uint64_t MCTP_TAG_TIMEOUT = 6000;
 
@@ -84,6 +88,14 @@ struct mctp_req_tag {
 	uint64_t expiry;
 };
 
+#define MCTP_CONTROL_MAX_TYPES 10
+
+struct mctp_control {
+	/* Types to report from Get MCTP Version Support */
+	uint8_t msg_types[MCTP_CONTROL_MAX_TYPES];
+	size_t num_msg_types;
+};
+
 struct mctp {
 	int n_busses;
 	struct mctp_bus busses[MCTP_MAX_BUSSES];
@@ -109,6 +121,10 @@ struct mctp {
 		ROUTE_BRIDGE,
 	} route_policy;
 	size_t max_message_size;
+
+#if MCTP_CONTROL_HANDLER
+	struct mctp_control control;
+#endif
 
 	void *alloc_ctx;
 

--- a/core.c
+++ b/core.c
@@ -72,13 +72,6 @@ struct mctp {
 	size_t max_message_size;
 };
 
-#ifndef BUILD_ASSERT
-#define BUILD_ASSERT(x)                                                        \
-	do {                                                                   \
-		(void)sizeof(char[0 - (!(x))]);                                \
-	} while (0)
-#endif
-
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #endif
@@ -317,7 +310,7 @@ void mctp_destroy(struct mctp *mctp)
 	size_t i;
 
 	/* Cleanup message assembly contexts */
-	BUILD_ASSERT(ARRAY_SIZE(mctp->msg_ctxs) < SIZE_MAX);
+	static_assert(ARRAY_SIZE(mctp->msg_ctxs) < SIZE_MAX, "size");
 	for (i = 0; i < ARRAY_SIZE(mctp->msg_ctxs); i++) {
 		struct mctp_msg_ctx *tmp = &mctp->msg_ctxs[i];
 		if (tmp->buf)
@@ -439,8 +432,11 @@ done:
 
 static inline bool mctp_ctrl_cmd_is_transport(struct mctp_ctrl_msg_hdr *hdr)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
 	return ((hdr->command_code >= MCTP_CTRL_CMD_FIRST_TRANSPORT) &&
 		(hdr->command_code <= MCTP_CTRL_CMD_LAST_TRANSPORT));
+#pragma GCC diagnostic pop
 }
 
 static bool mctp_ctrl_handle_msg(struct mctp_bus *bus, mctp_eid_t src,

--- a/core.c
+++ b/core.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdalign.h>
 
 #undef pr_fmt
 #define pr_fmt(fmt) "core: " fmt
@@ -65,6 +66,8 @@ void mctp_pktbuf_free(struct mctp_pktbuf *pkt)
 struct mctp_pktbuf *mctp_pktbuf_init(struct mctp_binding *binding,
 				     void *storage)
 {
+	assert((size_t)storage % alignof(struct mctp_pktbuf) == 0);
+
 	size_t size =
 		binding->pkt_size + binding->pkt_header + binding->pkt_trailer;
 	struct mctp_pktbuf *buf = (struct mctp_pktbuf *)storage;

--- a/core.c
+++ b/core.c
@@ -549,7 +549,7 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 	assert(bus);
 
 	/* Drop packet if it was smaller than mctp hdr size */
-	if (mctp_pktbuf_size(pkt) <= sizeof(struct mctp_hdr))
+	if (mctp_pktbuf_size(pkt) < sizeof(struct mctp_hdr))
 		goto out;
 
 	if (mctp->capture)

--- a/core.c
+++ b/core.c
@@ -568,6 +568,11 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 
 	hdr = mctp_pktbuf_hdr(pkt);
 
+	if (hdr->src == MCTP_EID_BROADCAST) {
+		/* drop packets with broadcast EID src */
+		goto out;
+	}
+
 	/* small optimisation: don't bother reassembly if we're going to
 	 * drop the packet in mctp_rx anyway */
 	if (mctp->route_policy == ROUTE_ENDPOINT &&

--- a/core.c
+++ b/core.c
@@ -17,6 +17,7 @@
 #include "libmctp-log.h"
 #include "libmctp-cmds.h"
 #include "range.h"
+#include "compiler.h"
 
 /* Internal data structures */
 
@@ -30,19 +31,33 @@ struct mctp_bus {
 	mctp_eid_t eid;
 	struct mctp_binding *binding;
 	enum mctp_bus_state state;
+	struct mctp *mctp;
 
-	struct mctp_pktbuf *tx_queue_head;
-	struct mctp_pktbuf *tx_queue_tail;
+	/* Current message to transmit */
+	void *tx_msg;
+	/* Position in tx_msg */
+	size_t tx_msgpos;
+	/* Length of tx_msg */
+	size_t tx_msglen;
+	/* Length of current packet payload */
+	size_t tx_pktlen;
+	uint8_t tx_seq;
+	uint8_t tx_src;
+	uint8_t tx_dest;
+	bool tx_to;
+	uint8_t tx_tag;
 
 	/* todo: routing */
 };
 
 struct mctp_msg_ctx {
+	/* NULL buf indicates an unused mctp_msg_ctx */
+	void *buf;
+
 	uint8_t src;
 	uint8_t dest;
 	uint8_t tag;
 	uint8_t last_seq;
-	void *buf;
 	size_t buf_size;
 	size_t buf_alloc_size;
 	size_t fragment_size;
@@ -70,6 +85,8 @@ struct mctp {
 		ROUTE_BRIDGE,
 	} route_policy;
 	size_t max_message_size;
+
+	void *alloc_ctx;
 };
 
 #ifndef ARRAY_SIZE
@@ -88,32 +105,44 @@ static int mctp_message_tx_on_bus(struct mctp_bus *bus, mctp_eid_t src,
 
 struct mctp_pktbuf *mctp_pktbuf_alloc(struct mctp_binding *binding, size_t len)
 {
-	struct mctp_pktbuf *buf;
-	size_t size;
-
-	size = binding->pkt_size + binding->pkt_header + binding->pkt_trailer;
+	size_t size =
+		binding->pkt_size + binding->pkt_header + binding->pkt_trailer;
 	if (len > size) {
 		return NULL;
 	}
 
-	/* todo: pools */
-	buf = __mctp_alloc(sizeof(*buf) + size);
-
-	if (!buf)
+	void *storage = __mctp_alloc(size + sizeof(struct mctp_pktbuf));
+	if (!storage) {
 		return NULL;
-
-	buf->size = size;
-	buf->start = binding->pkt_header;
-	buf->end = buf->start + len;
-	buf->mctp_hdr_off = buf->start;
-	buf->next = NULL;
-
-	return buf;
+	}
+	struct mctp_pktbuf *pkt = mctp_pktbuf_init(binding, storage);
+	pkt->alloc = true;
+	pkt->end = pkt->start + len;
+	return pkt;
 }
 
 void mctp_pktbuf_free(struct mctp_pktbuf *pkt)
 {
-	__mctp_free(pkt);
+	if (pkt->alloc) {
+		__mctp_free(pkt);
+	} else {
+		mctp_prdebug("pktbuf_free called for non-alloced");
+	}
+}
+
+struct mctp_pktbuf *mctp_pktbuf_init(struct mctp_binding *binding,
+				     void *storage)
+{
+	size_t size =
+		binding->pkt_size + binding->pkt_header + binding->pkt_trailer;
+	struct mctp_pktbuf *buf = (struct mctp_pktbuf *)storage;
+	buf->size = size;
+	buf->start = binding->pkt_header;
+	buf->end = buf->start;
+	buf->mctp_hdr_off = buf->start;
+	buf->alloc = false;
+
+	return buf;
 }
 
 struct mctp_hdr *mctp_pktbuf_hdr(struct mctp_pktbuf *pkt)
@@ -126,7 +155,7 @@ void *mctp_pktbuf_data(struct mctp_pktbuf *pkt)
 	return pkt->data + pkt->mctp_hdr_off + sizeof(struct mctp_hdr);
 }
 
-size_t mctp_pktbuf_size(struct mctp_pktbuf *pkt)
+size_t mctp_pktbuf_size(const struct mctp_pktbuf *pkt)
 {
 	return pkt->end - pkt->start;
 }
@@ -172,6 +201,19 @@ void *mctp_pktbuf_pop(struct mctp_pktbuf *pkt, size_t len)
 	return pkt->data + pkt->end;
 }
 
+/* Allocate a duplicate of the message and copy it */
+static void *mctp_msg_dup(const void *msg, size_t msg_len, struct mctp *mctp)
+{
+	void *copy = __mctp_msg_alloc(msg_len, mctp);
+	if (!copy) {
+		mctp_prdebug("msg dup len %zu failed", msg_len);
+		return NULL;
+	}
+
+	memcpy(copy, msg, msg_len);
+	return copy;
+}
+
 /* Message reassembly */
 static struct mctp_msg_ctx *mctp_msg_ctx_lookup(struct mctp *mctp, uint8_t src,
 						uint8_t dest, uint8_t tag)
@@ -182,7 +224,8 @@ static struct mctp_msg_ctx *mctp_msg_ctx_lookup(struct mctp *mctp, uint8_t src,
 	 * message contexts */
 	for (i = 0; i < ARRAY_SIZE(mctp->msg_ctxs); i++) {
 		struct mctp_msg_ctx *ctx = &mctp->msg_ctxs[i];
-		if (ctx->src == src && ctx->dest == dest && ctx->tag == tag)
+		if (ctx->buf && ctx->src == src && ctx->dest == dest &&
+		    ctx->tag == tag)
 			return ctx;
 	}
 
@@ -197,7 +240,7 @@ static struct mctp_msg_ctx *mctp_msg_ctx_create(struct mctp *mctp, uint8_t src,
 
 	for (i = 0; i < ARRAY_SIZE(mctp->msg_ctxs); i++) {
 		struct mctp_msg_ctx *tmp = &mctp->msg_ctxs[i];
-		if (!tmp->src) {
+		if (!tmp->buf) {
 			ctx = tmp;
 			break;
 		}
@@ -209,14 +252,22 @@ static struct mctp_msg_ctx *mctp_msg_ctx_create(struct mctp *mctp, uint8_t src,
 	ctx->src = src;
 	ctx->dest = dest;
 	ctx->tag = tag;
+
 	ctx->buf_size = 0;
+	ctx->buf_alloc_size = mctp->max_message_size;
+	ctx->buf = __mctp_msg_alloc(ctx->buf_alloc_size, mctp);
+	if (!ctx->buf) {
+		return NULL;
+	}
 
 	return ctx;
 }
 
-static void mctp_msg_ctx_drop(struct mctp_msg_ctx *ctx)
+static void mctp_msg_ctx_drop(struct mctp_bus *bus, struct mctp_msg_ctx *ctx)
 {
-	ctx->src = 0;
+	/* Free and mark as unused */
+	__mctp_msg_free(ctx->buf, bus->mctp);
+	ctx->buf = NULL;
 }
 
 static void mctp_msg_ctx_reset(struct mctp_msg_ctx *ctx)
@@ -226,7 +277,7 @@ static void mctp_msg_ctx_reset(struct mctp_msg_ctx *ctx)
 }
 
 static int mctp_msg_ctx_add_pkt(struct mctp_msg_ctx *ctx,
-				struct mctp_pktbuf *pkt, size_t max_size)
+				struct mctp_pktbuf *pkt)
 {
 	size_t len;
 
@@ -237,29 +288,7 @@ static int mctp_msg_ctx_add_pkt(struct mctp_msg_ctx *ctx,
 	}
 
 	if (ctx->buf_size + len > ctx->buf_alloc_size) {
-		size_t new_alloc_size;
-		void *lbuf;
-
-		/* @todo: finer-grained allocation */
-		if (!ctx->buf_alloc_size) {
-			new_alloc_size = MAX(len, 4096UL);
-		} else {
-			new_alloc_size = MAX(ctx->buf_alloc_size * 2,
-					     len + ctx->buf_size);
-		}
-
-		/* Don't allow heap to grow beyond a limit */
-		if (new_alloc_size > max_size)
-			return -1;
-
-		lbuf = __mctp_realloc(ctx->buf, new_alloc_size);
-		if (lbuf) {
-			ctx->buf = lbuf;
-			ctx->buf_alloc_size = new_alloc_size;
-		} else {
-			__mctp_free(ctx->buf);
-			return -1;
-		}
+		return -1;
 	}
 
 	memcpy((uint8_t *)ctx->buf + ctx->buf_size, mctp_pktbuf_data(pkt), len);
@@ -295,13 +324,11 @@ void mctp_set_capture_handler(struct mctp *mctp, mctp_capture_fn fn, void *user)
 	mctp->capture_data = user;
 }
 
-static void mctp_bus_destroy(struct mctp_bus *bus)
+static void mctp_bus_destroy(struct mctp_bus *bus, struct mctp *mctp)
 {
-	while (bus->tx_queue_head) {
-		struct mctp_pktbuf *curr = bus->tx_queue_head;
-
-		bus->tx_queue_head = curr->next;
-		mctp_pktbuf_free(curr);
+	if (bus->tx_msg) {
+		__mctp_msg_free(bus->tx_msg, mctp);
+		bus->tx_msg = NULL;
 	}
 }
 
@@ -314,11 +341,11 @@ void mctp_destroy(struct mctp *mctp)
 	for (i = 0; i < ARRAY_SIZE(mctp->msg_ctxs); i++) {
 		struct mctp_msg_ctx *tmp = &mctp->msg_ctxs[i];
 		if (tmp->buf)
-			__mctp_free(tmp->buf);
+			__mctp_msg_free(tmp->buf, mctp);
 	}
 
 	while (mctp->n_busses--)
-		mctp_bus_destroy(&mctp->busses[mctp->n_busses]);
+		mctp_bus_destroy(&mctp->busses[mctp->n_busses], mctp);
 
 	__mctp_free(mctp->busses);
 	__mctp_free(mctp);
@@ -351,11 +378,14 @@ int mctp_register_bus(struct mctp *mctp, struct mctp_binding *binding,
 	assert(mctp->n_busses == 0);
 	mctp->n_busses = 1;
 
+	assert(binding->tx_storage);
+
 	mctp->busses = __mctp_alloc(sizeof(struct mctp_bus));
 	if (!mctp->busses)
 		return -ENOMEM;
 
 	memset(mctp->busses, 0, sizeof(struct mctp_bus));
+	mctp->busses[0].mctp = mctp;
 	mctp->busses[0].binding = binding;
 	mctp->busses[0].eid = eid;
 	binding->bus = &mctp->busses[0];
@@ -392,6 +422,9 @@ int mctp_bridge_busses(struct mctp *mctp, struct mctp_binding *b1,
 		       struct mctp_binding *b2)
 {
 	int rc = 0;
+
+	assert(b1->tx_storage);
+	assert(b2->tx_storage);
 
 	assert(mctp->n_busses == 0);
 	mctp->busses = __mctp_alloc(2 * sizeof(struct mctp_bus));
@@ -524,8 +557,13 @@ static void mctp_rx(struct mctp *mctp, struct mctp_bus *bus, mctp_eid_t src,
 			if (dest_bus == bus)
 				continue;
 
+			void *copy = mctp_msg_dup(buf, len, mctp);
+			if (!copy) {
+				return;
+			}
+
 			mctp_message_tx_on_bus(dest_bus, src, dest, tag_owner,
-					       msg_tag, buf, len);
+					       msg_tag, copy, len);
 		}
 	}
 }
@@ -571,8 +609,14 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 		/* single-packet message - send straight up to rx function,
 		 * no need to create a message context */
 		len = pkt->end - pkt->mctp_hdr_off - sizeof(struct mctp_hdr);
-		p = pkt->data + pkt->mctp_hdr_off + sizeof(struct mctp_hdr);
-		mctp_rx(mctp, bus, hdr->src, hdr->dest, tag_owner, tag, p, len);
+		p = mctp_msg_dup(pkt->data + pkt->mctp_hdr_off +
+					 sizeof(struct mctp_hdr),
+				 len, mctp);
+		if (p) {
+			mctp_rx(mctp, bus, hdr->src, hdr->dest, tag_owner, tag,
+				p, len);
+			__mctp_msg_free(p, mctp);
+		}
 		break;
 
 	case MCTP_HDR_FLAG_SOM:
@@ -597,9 +641,9 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 		 * should of the same size */
 		ctx->fragment_size = mctp_pktbuf_size(pkt);
 
-		rc = mctp_msg_ctx_add_pkt(ctx, pkt, mctp->max_message_size);
+		rc = mctp_msg_ctx_add_pkt(ctx, pkt);
 		if (rc) {
-			mctp_msg_ctx_drop(ctx);
+			mctp_msg_ctx_drop(bus, ctx);
 		} else {
 			ctx->last_seq = seq;
 		}
@@ -617,7 +661,7 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 			mctp_prdebug(
 				"Sequence number %d does not match expected %d",
 				seq, exp_seq);
-			mctp_msg_ctx_drop(ctx);
+			mctp_msg_ctx_drop(bus, ctx);
 			goto out;
 		}
 
@@ -627,16 +671,16 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 			mctp_prdebug("Unexpected fragment size. Expected"
 				     " less than %zu, received = %zu",
 				     ctx->fragment_size, len);
-			mctp_msg_ctx_drop(ctx);
+			mctp_msg_ctx_drop(bus, ctx);
 			goto out;
 		}
 
-		rc = mctp_msg_ctx_add_pkt(ctx, pkt, mctp->max_message_size);
+		rc = mctp_msg_ctx_add_pkt(ctx, pkt);
 		if (!rc)
 			mctp_rx(mctp, bus, ctx->src, ctx->dest, tag_owner, tag,
 				ctx->buf, ctx->buf_size);
 
-		mctp_msg_ctx_drop(ctx);
+		mctp_msg_ctx_drop(bus, ctx);
 		break;
 
 	case 0:
@@ -650,7 +694,7 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 			mctp_prdebug(
 				"Sequence number %d does not match expected %d",
 				seq, exp_seq);
-			mctp_msg_ctx_drop(ctx);
+			mctp_msg_ctx_drop(bus, ctx);
 			goto out;
 		}
 
@@ -660,13 +704,13 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 			mctp_prdebug("Unexpected fragment size. Expected = %zu "
 				     "received = %zu",
 				     ctx->fragment_size, len);
-			mctp_msg_ctx_drop(ctx);
+			mctp_msg_ctx_drop(bus, ctx);
 			goto out;
 		}
 
-		rc = mctp_msg_ctx_add_pkt(ctx, pkt, mctp->max_message_size);
+		rc = mctp_msg_ctx_add_pkt(ctx, pkt);
 		if (rc) {
-			mctp_msg_ctx_drop(ctx);
+			mctp_msg_ctx_drop(bus, ctx);
 			goto out;
 		}
 		ctx->last_seq = seq;
@@ -674,15 +718,17 @@ void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt)
 		break;
 	}
 out:
-	mctp_pktbuf_free(pkt);
+	return;
 }
 
 static int mctp_packet_tx(struct mctp_bus *bus, struct mctp_pktbuf *pkt)
 {
 	struct mctp *mctp = bus->binding->mctp;
 
-	if (bus->state != mctp_bus_state_tx_enabled)
+	if (bus->state != mctp_bus_state_tx_enabled) {
+		mctp_prdebug("tx with bus disabled");
 		return -1;
+	}
 
 	if (mctp->capture)
 		mctp->capture(pkt, MCTP_MESSAGE_CAPTURE_OUTGOING,
@@ -691,36 +737,95 @@ static int mctp_packet_tx(struct mctp_bus *bus, struct mctp_pktbuf *pkt)
 	return bus->binding->tx(bus->binding, pkt);
 }
 
+/* Returns a pointer to the binding's tx_storage */
+static struct mctp_pktbuf *mctp_next_tx_pkt(struct mctp_bus *bus)
+{
+	if (!bus->tx_msg) {
+		return NULL;
+	}
+
+	size_t p = bus->tx_msgpos;
+	size_t msg_len = bus->tx_msglen;
+	size_t payload_len = msg_len - p;
+	size_t max_payload_len = MCTP_BODY_SIZE(bus->binding->pkt_size);
+	if (payload_len > max_payload_len)
+		payload_len = max_payload_len;
+
+	struct mctp_pktbuf *pkt =
+		mctp_pktbuf_init(bus->binding, bus->binding->tx_storage);
+	struct mctp_hdr *hdr = mctp_pktbuf_hdr(pkt);
+
+	hdr->ver = bus->binding->version & 0xf;
+	hdr->dest = bus->tx_dest;
+	hdr->src = bus->tx_src;
+	hdr->flags_seq_tag = (bus->tx_to << MCTP_HDR_TO_SHIFT) |
+			     (bus->tx_tag << MCTP_HDR_TAG_SHIFT);
+
+	if (p == 0)
+		hdr->flags_seq_tag |= MCTP_HDR_FLAG_SOM;
+	if (p + payload_len >= msg_len)
+		hdr->flags_seq_tag |= MCTP_HDR_FLAG_EOM;
+	hdr->flags_seq_tag |= bus->tx_seq << MCTP_HDR_SEQ_SHIFT;
+
+	memcpy(mctp_pktbuf_data(pkt), (uint8_t *)bus->tx_msg + p, payload_len);
+	pkt->end = pkt->start + sizeof(*hdr) + payload_len;
+	bus->tx_pktlen = payload_len;
+
+	mctp_prdebug(
+		"tx dst %d tag %d payload len %zu seq %d. msg pos %zu len %zu",
+		hdr->dest, bus->tx_tag, payload_len, bus->tx_seq, p, msg_len);
+
+	return pkt;
+}
+
+/* Called when a packet has successfully been sent */
+static void mctp_tx_complete(struct mctp_bus *bus)
+{
+	if (!bus->tx_msg) {
+		mctp_prdebug("tx complete no message");
+		return;
+	}
+
+	bus->tx_seq = (bus->tx_seq + 1) & MCTP_HDR_SEQ_MASK;
+	bus->tx_msgpos += bus->tx_pktlen;
+
+	if (bus->tx_msgpos >= bus->tx_msglen) {
+		__mctp_msg_free(bus->tx_msg, bus->binding->mctp);
+		bus->tx_msg = NULL;
+	}
+}
+
 static void mctp_send_tx_queue(struct mctp_bus *bus)
 {
 	struct mctp_pktbuf *pkt;
 
-	while ((pkt = bus->tx_queue_head)) {
+	while (bus->tx_msg && bus->state == mctp_bus_state_tx_enabled) {
 		int rc;
+
+		pkt = mctp_next_tx_pkt(bus);
 
 		rc = mctp_packet_tx(bus, pkt);
 		switch (rc) {
-		/* If transmission succeded, or */
+		/* If transmission succeded */
 		case 0:
-		/* If the packet is somehow too large */
-		case -EMSGSIZE:
 			/* Drop the packet */
-			bus->tx_queue_head = pkt->next;
-			mctp_pktbuf_free(pkt);
+			mctp_tx_complete(bus);
 			break;
 
-		/* If the binding was busy, or */
+		/* If the binding was busy */
 		case -EBUSY:
+			/* Keep the packet for next try */
+			mctp_prdebug("tx EBUSY");
+			return;
+
 		/* Some other unknown error occurred */
 		default:
-			/* Make sure the tail pointer is consistent and retry later */
-			goto cleanup_tail;
+			/* Drop the packet */
+			mctp_prdebug("tx drop %d", rc);
+			mctp_tx_complete(bus);
+			return;
 		};
 	}
-
-cleanup_tail:
-	if (!bus->tx_queue_head)
-		bus->tx_queue_tail = NULL;
 }
 
 void mctp_binding_set_tx_enabled(struct mctp_binding *binding, bool enable)
@@ -765,74 +870,60 @@ static int mctp_message_tx_on_bus(struct mctp_bus *bus, mctp_eid_t src,
 				  mctp_eid_t dest, bool tag_owner,
 				  uint8_t msg_tag, void *msg, size_t msg_len)
 {
-	size_t max_payload_len, payload_len, p;
-	struct mctp_pktbuf *pkt;
-	struct mctp_hdr *hdr;
-	int i;
+	size_t max_payload_len;
+	int rc;
 
-	if (bus->state == mctp_bus_state_constructed)
-		return -ENXIO;
+	if (bus->state == mctp_bus_state_constructed) {
+		rc = -ENXIO;
+		goto err;
+	}
 
-	if ((msg_tag & MCTP_HDR_TAG_MASK) != msg_tag)
-		return -EINVAL;
+	if ((msg_tag & MCTP_HDR_TAG_MASK) != msg_tag) {
+		rc = -EINVAL;
+		goto err;
+	}
 
 	max_payload_len = MCTP_BODY_SIZE(bus->binding->pkt_size);
 
 	{
 		const bool valid_mtu = max_payload_len >= MCTP_BTU;
 		assert(valid_mtu);
-		if (!valid_mtu)
-			return -EINVAL;
+		if (!valid_mtu) {
+			rc = -EINVAL;
+			goto err;
+		}
 	}
 
 	mctp_prdebug(
 		"%s: Generating packets for transmission of %zu byte message from %hhu to %hhu",
 		__func__, msg_len, src, dest);
 
-	/* queue up packets, each of max MCTP_MTU size */
-	for (p = 0, i = 0; p < msg_len; i++) {
-		payload_len = msg_len - p;
-		if (payload_len > max_payload_len)
-			payload_len = max_payload_len;
-
-		pkt = mctp_pktbuf_alloc(bus->binding,
-					payload_len + sizeof(*hdr));
-		hdr = mctp_pktbuf_hdr(pkt);
-
-		hdr->ver = bus->binding->version & 0xf;
-		hdr->dest = dest;
-		hdr->src = src;
-		hdr->flags_seq_tag = (tag_owner << MCTP_HDR_TO_SHIFT) |
-				     (msg_tag << MCTP_HDR_TAG_SHIFT);
-
-		if (i == 0)
-			hdr->flags_seq_tag |= MCTP_HDR_FLAG_SOM;
-		if (p + payload_len >= msg_len)
-			hdr->flags_seq_tag |= MCTP_HDR_FLAG_EOM;
-		hdr->flags_seq_tag |= (i & MCTP_HDR_SEQ_MASK)
-				      << MCTP_HDR_SEQ_SHIFT;
-
-		memcpy(mctp_pktbuf_data(pkt), (uint8_t *)msg + p, payload_len);
-
-		/* add to tx queue */
-		if (bus->tx_queue_tail)
-			bus->tx_queue_tail->next = pkt;
-		else
-			bus->tx_queue_head = pkt;
-		bus->tx_queue_tail = pkt;
-
-		p += payload_len;
+	if (bus->tx_msg) {
+		mctp_prdebug("Bus busy");
+		rc = -EBUSY;
+		goto err;
 	}
 
-	mctp_prdebug("%s: Enqueued %d packets", __func__, i);
+	/* Take the message to send */
+	bus->tx_msg = msg;
+	bus->tx_msglen = msg_len;
+	bus->tx_msgpos = 0;
+	/* bus->tx_seq is allowed to continue from previous message */
+	bus->tx_src = src;
+	bus->tx_dest = dest;
+	bus->tx_to = tag_owner;
+	bus->tx_tag = msg_tag;
 
 	mctp_send_tx_queue(bus);
-
 	return 0;
+
+err:
+	__mctp_msg_free(msg, bus->binding->mctp);
+	return rc;
 }
 
-int mctp_message_tx(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
-		    uint8_t msg_tag, void *msg, size_t msg_len)
+int mctp_message_tx_alloced(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
+			    uint8_t msg_tag, void *msg, size_t msg_len)
 {
 	struct mctp_bus *bus;
 
@@ -840,13 +931,49 @@ int mctp_message_tx(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
 	 * different callers */
 	if ((msg_tag & MCTP_HDR_TAG_MASK) != msg_tag) {
 		mctp_prerr("Incorrect message tag %u passed.", msg_tag);
+		__mctp_msg_free(msg, mctp);
 		return -EINVAL;
 	}
 
 	bus = find_bus_for_eid(mctp, eid);
-	if (!bus)
+	if (!bus) {
+		__mctp_msg_free(msg, mctp);
 		return 0;
+	}
 
 	return mctp_message_tx_on_bus(bus, bus->eid, eid, tag_owner, msg_tag,
 				      msg, msg_len);
+}
+
+int mctp_message_tx(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
+		    uint8_t msg_tag, const void *msg, size_t msg_len)
+{
+	void *copy = mctp_msg_dup(msg, msg_len, mctp);
+	if (!copy) {
+		return -ENOMEM;
+	}
+
+	return mctp_message_tx_alloced(mctp, eid, tag_owner, msg_tag, copy,
+				       msg_len);
+}
+
+bool mctp_is_tx_ready(struct mctp *mctp, mctp_eid_t eid)
+{
+	struct mctp_bus *bus;
+
+	bus = find_bus_for_eid(mctp, eid);
+	if (!bus) {
+		return true;
+	}
+	return bus->tx_msg == NULL;
+}
+
+void *mctp_get_alloc_ctx(struct mctp *mctp)
+{
+	return mctp->alloc_ctx;
+}
+
+void mctp_set_alloc_ctx(struct mctp *mctp, void *ctx)
+{
+	mctp->alloc_ctx = ctx;
 }

--- a/core.c
+++ b/core.c
@@ -155,7 +155,7 @@ void *mctp_pktbuf_alloc_end(struct mctp_pktbuf *pkt, size_t size)
 	return buf;
 }
 
-int mctp_pktbuf_push(struct mctp_pktbuf *pkt, void *data, size_t len)
+int mctp_pktbuf_push(struct mctp_pktbuf *pkt, const void *data, size_t len)
 {
 	void *p;
 

--- a/core.c
+++ b/core.c
@@ -20,6 +20,10 @@
 #include "compiler.h"
 #include "core-internal.h"
 
+#if MCTP_DEFAULT_CLOCK_GETTIME
+#include <time.h>
+#endif
+
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #endif
@@ -238,6 +242,19 @@ struct mctp *mctp_init(void)
 	return mctp;
 }
 
+#if MCTP_DEFAULT_CLOCK_GETTIME
+static uint64_t mctp_default_now(void *ctx __attribute__((unused)))
+{
+	struct timespec tp;
+	int rc = clock_gettime(CLOCK_MONOTONIC, &tp);
+	if (rc) {
+		/* Should not be possible */
+		return 0;
+	}
+	return (uint64_t)tp.tv_sec * 1000 + tp.tv_nsec / 1000000;
+}
+#endif
+
 int mctp_setup(struct mctp *mctp, size_t struct_mctp_size)
 {
 	if (struct_mctp_size < sizeof(struct mctp)) {
@@ -246,6 +263,9 @@ int mctp_setup(struct mctp *mctp, size_t struct_mctp_size)
 	}
 	memset(mctp, 0, sizeof(*mctp));
 	mctp->max_message_size = MCTP_MAX_MESSAGE_SIZE;
+#if MCTP_DEFAULT_CLOCK_GETTIME
+	mctp->platform_now = mctp_default_now;
+#endif
 	return 0;
 }
 
@@ -893,11 +913,24 @@ int mctp_message_tx(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
 				       msg_len);
 }
 
+void mctp_set_now_op(struct mctp *mctp, uint64_t (*now)(void *), void *ctx)
+{
+	assert(now);
+	mctp->platform_now = now;
+	mctp->platform_now_ctx = ctx;
+}
+
+uint64_t mctp_now(struct mctp *mctp)
+{
+	assert(mctp->platform_now);
+	return mctp->platform_now(mctp->platform_now_ctx);
+}
+
 static void mctp_dealloc_tag(struct mctp_bus *bus, mctp_eid_t local,
 			     mctp_eid_t remote, uint8_t tag)
 {
 	struct mctp *mctp = bus->binding->mctp;
-	if (local == 0 || remote == 0) {
+	if (local == 0) {
 		return;
 	}
 
@@ -907,6 +940,7 @@ static void mctp_dealloc_tag(struct mctp_bus *bus, mctp_eid_t local,
 			r->local = 0;
 			r->remote = 0;
 			r->tag = 0;
+			r->expiry = 0;
 			return;
 		}
 	}
@@ -916,17 +950,16 @@ static int mctp_alloc_tag(struct mctp *mctp, mctp_eid_t local,
 			  mctp_eid_t remote, uint8_t *ret_tag)
 {
 	assert(local != 0);
-	assert(remote != 0);
+	uint64_t now = mctp_now(mctp);
 
 	uint8_t used = 0;
 	struct mctp_req_tag *spare = NULL;
 	/* Find which tags and slots are used/spare */
 	for (size_t i = 0; i < ARRAY_SIZE(mctp->req_tags); i++) {
 		struct mctp_req_tag *r = &mctp->req_tags[i];
-		if (r->local == 0) {
+		if (r->local == 0 || r->expiry < now) {
 			spare = r;
 		} else {
-			// TODO: check timeouts
 			if (r->local == local && r->remote == remote) {
 				used |= 1 << r->tag;
 			}
@@ -944,6 +977,7 @@ static int mctp_alloc_tag(struct mctp *mctp, mctp_eid_t local,
 			spare->local = local;
 			spare->remote = remote;
 			spare->tag = tag;
+			spare->expiry = now + MCTP_TAG_TIMEOUT;
 			*ret_tag = tag;
 			mctp->tag_round_robin = (tag + 1) % 8;
 			return 0;

--- a/core.c
+++ b/core.c
@@ -790,7 +790,7 @@ static void mctp_send_tx_queue(struct mctp_bus *bus)
 
 		rc = mctp_packet_tx(bus, pkt);
 		switch (rc) {
-		/* If transmission succeded */
+		/* If transmission succeeded */
 		case 0:
 			/* Drop the packet */
 			mctp_tx_complete(bus);

--- a/core.c
+++ b/core.c
@@ -27,7 +27,7 @@
 #endif
 
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #endif
 
 static int mctp_message_tx_on_bus(struct mctp_bus *bus, mctp_eid_t src,

--- a/core.c
+++ b/core.c
@@ -23,7 +23,11 @@
 #include "control.h"
 
 #if MCTP_DEFAULT_CLOCK_GETTIME
+#if defined(__ZEPHYR__)
+#include <zephyr/kernel.h>
+#else
 #include <time.h>
+#endif
 #endif
 
 #ifndef ARRAY_SIZE
@@ -247,6 +251,12 @@ struct mctp *mctp_init(void)
 }
 
 #if MCTP_DEFAULT_CLOCK_GETTIME
+#if defined(__ZEPHYR__)
+static uint64_t mctp_default_now(void *ctx __attribute__((unused)))
+{
+	return (uint64_t)k_uptime_get();
+}
+#else
 static uint64_t mctp_default_now(void *ctx __attribute__((unused)))
 {
 	struct timespec tp;
@@ -257,6 +267,7 @@ static uint64_t mctp_default_now(void *ctx __attribute__((unused)))
 	}
 	return (uint64_t)tp.tv_sec * 1000 + tp.tv_nsec / 1000000;
 }
+#endif
 #endif
 
 int mctp_setup(struct mctp *mctp, size_t struct_mctp_size)

--- a/docs/bindings/vendor-ibm-astlpc.md
+++ b/docs/bindings/vendor-ibm-astlpc.md
@@ -93,7 +93,7 @@ versions of the protocol unless marked otherwise.
 
 ## MCTP over LPC Transport
 
-### Concepts
+### MCTP over LPC: Concepts
 
 The basic components used for the transfer are:
 
@@ -117,7 +117,7 @@ On this indication, the remote side will:
    interrupt
 3. Read the MCTP packet from the LPC FW window
 
-### Scope
+### MCTP over LPC: Scope
 
 The document limits itself to describing the operation of the binding protocol.
 The following issues of protocol ABI are considered out of scope:
@@ -377,7 +377,7 @@ below.
 The sequences below contain steps where the BMC updates the channel status and
 where commands are sent between the BMC and the host. The act of updating status
 or sending a command invokes the behaviour outlined in
-[KCS Control](#kcs-control).
+[KCS Control](#kcs-status-and-control-sequences).
 
 The packet transmission sequences assume that `BMC Active` and `Channel Active`
 are set.

--- a/docs/bindings/vendor-ibm-astlpc.md
+++ b/docs/bindings/vendor-ibm-astlpc.md
@@ -272,7 +272,7 @@ have asymmetric MTUs.
 For all protocol versions, the following properties must be upheld for the Rx
 and Tx buffers to be considered valid:
 
-- Intersect neither eachother nor the control region
+- Intersect neither each other nor the control region
 - Not extend beyond the window allocated to MCTP in the LPC FW address space
 - Must accommodate at least BTU-sized payloads
 

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,0 +1,80 @@
+# Fuzzing libmctp
+
+## Build
+
+From the top level libmctp directory, run `./tests/fuzz/fuzz-build.py`. That
+will produce several build variants required for different fuzz engines/stages.
+
+## Honggfuzz
+
+[Honggfuzz](https://github.com/google/honggfuzz) handles running across multiple
+threads itself with a single corpus directory, which is easy to work with. It
+needs to be built from source.
+
+Run with
+
+```
+nice honggfuzz -T -i corpusdir --linux_perf_branch -- ./bhf/tests/fuzz/i2c-fuzz
+```
+
+The `--linux_perf_branch` switch is optional, it requires permissions for perf
+counters:
+
+```
+echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
+```
+
+Optionally a thread count can be given, 24 threads on a 12 core system seems to
+give best utilisation (`--threads 24`).
+
+The corpus directory can be reused between runs with different fuzzers.
+
+## AFL++
+
+Running a single instance (just for testing):
+
+```
+afl-fuzz -i fuzzrun/hf11/ -o fuzzrun/out12single ./bfuzz/tests/fuzz/i2c-fuzz
+```
+
+AFL++ requires a separate TUI instantiation for each CPU thread. The helper
+[AFL Runner](https://github.com/0xricksanchez/afl_runner) makes that easier.
+
+Running with 20 threads:
+
+```
+nice aflr run  -t bfuzz/tests/fuzz/i2c-fuzz -i workdir/out5/m_i2c-fuzz/queue -o workdir/out6 -c bcmplog/tests/fuzz/i2c-fuzz -s bfuzzasan/tests/fuzz/i2c-fuzz -n 20  --session-name fuzz
+```
+
+Kill it with `aflr kill fuzz`.
+
+`aflr tui workdir/out6` could be used to view progress, though its calculations
+may be inaccurate if some runners are idle. Another option is
+`afl-whatsup workdir/out6`.
+
+## Coverage
+
+The coverage provided by a corpus directory can be reported using
+`tests/fuzz/fuzz-coverage.py`.
+
+It will:
+
+- Run a binary compiled with `--coverage` against each corpus file
+- Use [grcov](https://github.com/mozilla/grcov) to aggregate the coverage traces
+  (much faster than lcov).
+- Use `genhtml` to create a report
+
+Typical usage, with corpus in `fuzzrun/corpus`:
+
+```
+./tests/fuzz/fuzz-coverage.py fuzzrun/corpus bnoopt/tests/fuzz/i2c-fuzz . bnoopt/ coverage-output
+```
+
+## Reproducing crashes
+
+When the fuzz run encounters a crash, the testcase can be run against the built
+target manually, and stepped through with GDB etc.
+
+```
+./bnoopt/tests/fuzz/i2c-fuzz < crashing.bin
+```

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -13,14 +13,14 @@ needs to be built from source.
 
 Run with
 
-```
+```shell
 nice honggfuzz -T -i corpusdir --linux_perf_branch -- ./bhf/tests/fuzz/i2c-fuzz
 ```
 
 The `--linux_perf_branch` switch is optional, it requires permissions for perf
 counters:
 
-```
+```shell
 echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
 ```
 
@@ -33,7 +33,7 @@ The corpus directory can be reused between runs with different fuzzers.
 
 Running a single instance (just for testing):
 
-```
+```shell
 afl-fuzz -i fuzzrun/hf11/ -o fuzzrun/out12single ./bfuzz/tests/fuzz/i2c-fuzz
 ```
 
@@ -42,7 +42,7 @@ AFL++ requires a separate TUI instantiation for each CPU thread. The helper
 
 Running with 20 threads:
 
-```
+```shell
 nice aflr run  -t bfuzz/tests/fuzz/i2c-fuzz -i workdir/out5/m_i2c-fuzz/queue -o workdir/out6 -c bcmplog/tests/fuzz/i2c-fuzz -s bfuzzasan/tests/fuzz/i2c-fuzz -n 20  --session-name fuzz
 ```
 
@@ -66,7 +66,7 @@ It will:
 
 Typical usage, with corpus in `fuzzrun/corpus`:
 
-```
+```shell
 ./tests/fuzz/fuzz-coverage.py fuzzrun/corpus bnoopt/tests/fuzz/i2c-fuzz . bnoopt/ coverage-output
 ```
 
@@ -75,6 +75,6 @@ Typical usage, with corpus in `fuzzrun/corpus`:
 When the fuzz run encounters a crash, the testcase can be run against the built
 target manually, and stepped through with GDB etc.
 
-```
+```shell
 ./bnoopt/tests/fuzz/i2c-fuzz < crashing.bin
 ```

--- a/i2c-internal.h
+++ b/i2c-internal.h
@@ -35,10 +35,8 @@ struct mctp_binding_i2c {
 
 	uint8_t own_addr;
 
-	uint8_t tx_storage[sizeof(struct mctp_i2c_hdr) +
-			   MCTP_PKTBUF_SIZE(I2C_BTU)] __attribute((aligned(8)));
-	uint8_t rx_storage[sizeof(struct mctp_i2c_hdr) +
-			   MCTP_PKTBUF_SIZE(I2C_BTU)] __attribute((aligned(8)));
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(I2C_BTU)] PKTBUF_STORAGE_ALIGN;
+	uint8_t rx_storage[MCTP_PKTBUF_SIZE(I2C_BTU)] PKTBUF_STORAGE_ALIGN;
 
 	mctp_i2c_tx_fn tx_fn;
 	void *tx_ctx;

--- a/i2c-internal.h
+++ b/i2c-internal.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
+#pragma once
+
+#include <assert.h>
+#include "libmctp.h"
+#include "libmctp-i2c.h"
+
+/* Limited by bytecount field */
+static_assert(I2C_BTU <= 254);
+
+#ifndef MCTP_I2C_NEIGH_COUNT
+#define MCTP_I2C_NEIGH_COUNT 4
+#endif
+
+struct mctp_i2c_hdr {
+	uint8_t dest;
+	uint8_t cmd;
+	uint8_t bytecount;
+	uint8_t source;
+};
+
+struct mctp_i2c_neigh {
+	bool used;
+	/* 7-bit address */
+	uint8_t addr;
+	uint8_t eid;
+	/* from platform_now(), for LRU eviction */
+	uint64_t last_seen_timestamp;
+};
+
+struct mctp_binding_i2c {
+	struct mctp_binding binding;
+
+	struct mctp_i2c_neigh neigh[MCTP_I2C_NEIGH_COUNT];
+
+	uint8_t own_addr;
+
+	uint8_t tx_storage[sizeof(struct mctp_i2c_hdr) +
+			   MCTP_PKTBUF_SIZE(I2C_BTU)] __attribute((aligned(8)));
+	uint8_t rx_storage[sizeof(struct mctp_i2c_hdr) +
+			   MCTP_PKTBUF_SIZE(I2C_BTU)] __attribute((aligned(8)));
+
+	mctp_i2c_tx_fn tx_fn;
+	void *tx_ctx;
+};

--- a/i2c-internal.h
+++ b/i2c-internal.h
@@ -6,7 +6,7 @@
 #include "libmctp-i2c.h"
 
 /* Limited by bytecount field */
-static_assert(I2C_BTU <= 254);
+static_assert(I2C_BTU <= 254, "I2C BTU is limited to 254");
 
 #ifndef MCTP_I2C_NEIGH_COUNT
 #define MCTP_I2C_NEIGH_COUNT 4

--- a/i2c-internal.h
+++ b/i2c-internal.h
@@ -35,8 +35,10 @@ struct mctp_binding_i2c {
 
 	uint8_t own_addr;
 
-	uint8_t tx_storage[MCTP_PKTBUF_SIZE(I2C_BTU)] PKTBUF_STORAGE_ALIGN;
-	uint8_t rx_storage[MCTP_PKTBUF_SIZE(I2C_BTU)] PKTBUF_STORAGE_ALIGN;
+	uint8_t tx_storage[sizeof(struct mctp_i2c_hdr) +
+			   MCTP_PKTBUF_SIZE(I2C_BTU)] PKTBUF_STORAGE_ALIGN;
+	uint8_t rx_storage[sizeof(struct mctp_i2c_hdr) +
+			   MCTP_PKTBUF_SIZE(I2C_BTU)] PKTBUF_STORAGE_ALIGN;
 
 	mctp_i2c_tx_fn tx_fn;
 	void *tx_ctx;

--- a/i2c.c
+++ b/i2c.c
@@ -1,0 +1,278 @@
+/* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "libmctp.h"
+#include "libmctp-alloc.h"
+#include "libmctp-log.h"
+#include "container_of.h"
+#include "libmctp-i2c.h"
+#include "i2c-internal.h"
+
+static const uint8_t MCTP_I2C_COMMAND = 0x0f;
+
+#define binding_to_i2c(b) container_of(b, struct mctp_binding_i2c, binding)
+
+static bool mctp_i2c_valid_addr(uint8_t addr)
+{
+	return addr <= 0x7f;
+}
+
+static bool mctp_i2c_valid_eid(uint8_t eid)
+{
+	/* Disallow reserved range */
+	return eid >= 8 && eid < 0xff;
+}
+
+static int mctp_i2c_core_start(struct mctp_binding *binding)
+{
+	mctp_binding_set_tx_enabled(binding, true);
+	return 0;
+}
+
+/* Returns 0 if an entry is found, or -ENOENT otherwise.
+ * The last seen timestamp will be updated for found entries */
+static int mctp_i2c_neigh_get(struct mctp_binding_i2c *i2c, uint8_t eid,
+			      uint8_t *ret_neigh_addr)
+{
+	for (size_t i = 0; i < MCTP_I2C_NEIGH_COUNT; i++) {
+		struct mctp_i2c_neigh *n = &i2c->neigh[i];
+		if (n->used && n->eid == eid) {
+			n->last_seen_timestamp = mctp_now(i2c->binding.mctp);
+			*ret_neigh_addr = n->addr;
+			return 0;
+		}
+	}
+	return -ENOENT;
+}
+
+/* Adds a new neighbour entry. If the table is full, the oldest
+ * entry will be evicted. If eid already exists, that entry will
+ * be replaced. */
+static void mctp_i2c_neigh_add(struct mctp_binding_i2c *i2c, uint8_t eid,
+			       uint8_t addr)
+{
+	assert(addr <= 0x7f);
+	struct mctp_i2c_neigh *entry = NULL;
+	for (size_t i = 0; i < MCTP_I2C_NEIGH_COUNT; i++) {
+		struct mctp_i2c_neigh *n = &i2c->neigh[i];
+		if (!n->used) {
+			/* Spare entry, use it */
+			entry = n;
+			break;
+		}
+
+		if (n->eid == eid) {
+			/* Replacing existing entry */
+			entry = n;
+			break;
+		}
+
+		if (!entry ||
+		    n->last_seen_timestamp < entry->last_seen_timestamp) {
+			/* Use this as the provisional oldest, keep iterating */
+			entry = n;
+		}
+	}
+	assert(entry);
+
+	entry->addr = addr;
+	entry->eid = eid;
+	entry->used = true;
+	entry->last_seen_timestamp = mctp_now(i2c->binding.mctp);
+}
+
+static int mctp_binding_i2c_tx(struct mctp_binding *b, struct mctp_pktbuf *pkt)
+{
+	struct mctp_binding_i2c *i2c = binding_to_i2c(b);
+	struct mctp_hdr *hdr = mctp_pktbuf_hdr(pkt);
+	int rc;
+	uint8_t neigh_addr;
+
+	rc = mctp_i2c_neigh_get(i2c, hdr->dest, &neigh_addr);
+	if (rc) {
+		return rc;
+	}
+
+	struct mctp_i2c_hdr *i2c_hdr =
+		mctp_pktbuf_alloc_start(pkt, sizeof(struct mctp_i2c_hdr));
+	i2c_hdr->dest = neigh_addr << 1;
+	i2c_hdr->cmd = MCTP_I2C_COMMAND;
+	size_t bytecount = mctp_pktbuf_size(pkt) -
+			   (offsetof(struct mctp_i2c_hdr, bytecount) + 1);
+	if (bytecount > 0xff) {
+		return -EINVAL;
+	}
+	i2c_hdr->bytecount = bytecount;
+	i2c_hdr->source = i2c->own_addr << 1 | 1;
+
+	rc = i2c->tx_fn(pkt->data + pkt->start, mctp_pktbuf_size(pkt),
+			i2c->tx_ctx);
+	switch (rc) {
+	case -EMSGSIZE:
+	case 0:
+		break;
+	case -EBUSY:
+	default:
+		mctp_binding_set_tx_enabled(&i2c->binding, false);
+	}
+	return rc;
+}
+
+int mctp_i2c_set_neighbour(struct mctp_binding_i2c *i2c, uint8_t eid,
+			   uint8_t addr)
+{
+	if (!mctp_i2c_valid_eid(eid)) {
+		return -EINVAL;
+	}
+	if (!mctp_i2c_valid_addr(addr)) {
+		return -EINVAL;
+	}
+
+	mctp_i2c_neigh_add(i2c, eid, addr);
+	return 0;
+}
+
+int mctp_i2c_setup(struct mctp_binding_i2c *i2c, uint8_t own_addr,
+		   mctp_i2c_tx_fn tx_fn, void *tx_ctx)
+{
+	int rc;
+
+	memset(i2c, 0x0, sizeof(*i2c));
+
+	rc = mctp_i2c_set_address(i2c, own_addr);
+	if (rc) {
+		return rc;
+	}
+
+	i2c->binding.name = "i2c";
+	i2c->binding.version = 1;
+	i2c->binding.pkt_size = MCTP_PACKET_SIZE(I2C_BTU);
+	i2c->binding.pkt_header = sizeof(struct mctp_i2c_hdr);
+	i2c->binding.tx_storage = i2c->tx_storage;
+
+	i2c->binding.start = mctp_i2c_core_start;
+	i2c->binding.tx = mctp_binding_i2c_tx;
+
+	i2c->tx_fn = tx_fn;
+	i2c->tx_ctx = tx_ctx;
+
+	return 0;
+}
+
+int mctp_i2c_set_address(struct mctp_binding_i2c *i2c, uint8_t own_addr)
+{
+	if (!mctp_i2c_valid_addr(own_addr)) {
+		return -EINVAL;
+	}
+
+	i2c->own_addr = own_addr;
+	return 0;
+}
+
+struct mctp_binding *mctp_binding_i2c_core(struct mctp_binding_i2c *i2c)
+{
+	return &i2c->binding;
+}
+
+static int mctp_i2c_hdr_validate(const struct mctp_i2c_hdr *hdr)
+{
+	if (hdr->cmd != MCTP_I2C_COMMAND) {
+		return -EINVAL;
+	}
+	if ((hdr->dest & 1) != 0) {
+		return -EINVAL;
+	}
+	if ((hdr->source & 1) != 1) {
+		return -EINVAL;
+	}
+	return 0;
+}
+
+void mctp_i2c_rx(struct mctp_binding_i2c *i2c, const void *data, size_t len)
+{
+	int rc;
+
+	if (len < sizeof(struct mctp_i2c_hdr)) {
+		return;
+	}
+	const struct mctp_i2c_hdr *hdr = data;
+	rc = mctp_i2c_hdr_validate(hdr);
+	if (rc) {
+		return;
+	}
+
+	if (hdr->bytecount != len - 3) {
+		return;
+	}
+
+	if ((hdr->dest >> 1) != i2c->own_addr) {
+		return;
+	}
+
+	uint8_t src = hdr->source >> 1;
+	if (src == i2c->own_addr) {
+		return;
+	}
+
+	struct mctp_pktbuf *pkt =
+		mctp_pktbuf_init(&i2c->binding, i2c->rx_storage);
+	rc = mctp_pktbuf_push(
+		pkt, (const uint8_t *)data + sizeof(struct mctp_i2c_hdr),
+		len - sizeof(struct mctp_i2c_hdr));
+	if (rc) {
+		// Packet too large for I2C_BTU
+		return;
+	}
+
+	if (mctp_pktbuf_size(pkt) < sizeof(struct mctp_hdr)) {
+		return;
+	}
+
+	struct mctp_hdr *mctp_hdr = mctp_pktbuf_hdr(pkt);
+	if (mctp_hdr->flags_seq_tag & MCTP_HDR_FLAG_TO) {
+		/* Update neighbour entry */
+		mctp_i2c_neigh_add(i2c, mctp_hdr->src, src);
+	}
+
+	mctp_bus_rx(&i2c->binding, pkt);
+}
+
+int mctp_i2c_parse_hdr(const void *data, size_t len, uint8_t *src_addr,
+		       uint8_t *dest_addr, uint8_t *bytecount)
+{
+	int rc;
+
+	if (len < sizeof(struct mctp_i2c_hdr)) {
+		return -EINVAL;
+	}
+	const struct mctp_i2c_hdr *hdr = data;
+	rc = mctp_i2c_hdr_validate(hdr);
+	if (rc) {
+		return rc;
+	}
+
+	if (src_addr) {
+		*src_addr = hdr->source >> 1;
+	}
+	if (dest_addr) {
+		*dest_addr = hdr->dest >> 1;
+	}
+	if (bytecount) {
+		*bytecount = hdr->bytecount;
+	}
+	return 0;
+}
+
+void mctp_i2c_tx_poll(struct mctp_binding_i2c *i2c)
+{
+	mctp_binding_set_tx_enabled(&i2c->binding, true);
+}

--- a/libmctp-alloc.h
+++ b/libmctp-alloc.h
@@ -5,8 +5,12 @@
 
 #include <stdlib.h>
 
+struct mctp;
+
 void *__mctp_alloc(size_t size);
 void __mctp_free(void *ptr);
-void *__mctp_realloc(void *ptr, size_t size);
+
+void *__mctp_msg_alloc(size_t size, struct mctp *mctp);
+void __mctp_msg_free(void *ptr, struct mctp *mctp);
 
 #endif /* _LIBMCTP_ALLOC_H */

--- a/libmctp-cmds.h
+++ b/libmctp-cmds.h
@@ -66,6 +66,75 @@ struct mctp_ctrl_msg_hdr {
 #define MCTP_CTRL_CC_ERROR_UNSUPPORTED_CMD 0x05
 /* 0x80 - 0xFF are command specific */
 
+struct mctp_ctrl_cmd_empty_resp {
+	struct mctp_ctrl_msg_hdr hdr;
+	uint8_t completion_code;
+} __attribute__((packed));
+
+/* Set Endpoint ID request, Operation. Bits [1:0] */
+#define MCTP_CTRL_SET_EID_OP_MASK	    0x03
+#define MCTP_CTRL_SET_EID_OP_SET	    0x00
+#define MCTP_CTRL_SET_EID_OP_FORCE	    0x01
+#define MCTP_CTRL_SET_EID_OP_RESET	    0x02
+#define MCTP_CTRL_SET_EID_OP_SET_DISCOVERED 0x03
+
+struct mctp_ctrl_cmd_set_endpoint_id_req {
+	struct mctp_ctrl_msg_hdr hdr;
+	uint8_t operation;
+	uint8_t eid;
+} __attribute__((packed));
+
+/* Set Endpoint ID response, assignment status. Bits [1:0] */
+#define MCTP_CTRL_SET_EID_STATUS_ACCEPTED 0x00
+#define MCTP_CTRL_SET_EID_STATUS_REJECTED 0x01
+
+struct mctp_ctrl_cmd_set_endpoint_id_resp {
+	struct mctp_ctrl_msg_hdr hdr;
+	uint8_t completion_code;
+	uint8_t status;
+	uint8_t eid;
+	uint8_t pool_size;
+} __attribute__((packed));
+
+/* Get Endpoint ID, Endpoint Type. Bits [5:4] */
+#define MCTP_CTRL_ENDPOINT_TYPE_SIMPLE		0x00
+#define MCTP_CTRL_ENDPOINT_TYPE_BUSOWNER_BRIDGE 0x10
+
+/* Get Endpoint ID, Endpoint ID Type. Bits [1:0] */
+#define MCTP_CTRL_ENDPOINT_ID_TYPE_DYNAMIC_ONLY	    0x00
+#define MCTP_CTRL_ENDPOINT_ID_TYPE_STATIC	    0x01
+#define MCTP_CTRL_ENDPOINT_ID_TYPE_STATIC_SAME	    0x02
+#define MCTP_CTRL_ENDPOINT_ID_TYPE_STATIC_DIFFERENT 0x03
+
+struct mctp_ctrl_cmd_get_endpoint_id_resp {
+	struct mctp_ctrl_msg_hdr hdr;
+	uint8_t completion_code;
+	uint8_t endpoint_id;
+	uint8_t endpoint_type;
+	uint8_t medium_specific;
+} __attribute__((packed));
+
+#define MCTP_CTRL_VERSIONS_NOT_SUPPORTED 0x80
+
+struct mctp_ctrl_cmd_get_version_req {
+	struct mctp_ctrl_msg_hdr hdr;
+	uint8_t msg_type;
+} __attribute__((packed));
+
+struct mctp_ctrl_cmd_get_version_resp {
+	struct mctp_ctrl_msg_hdr hdr;
+	uint8_t completion_code;
+	uint8_t version_count;
+	uint32_t versions[];
+} __attribute__((packed));
+
+struct mctp_ctrl_cmd_get_types_resp {
+	struct mctp_ctrl_msg_hdr hdr;
+	uint8_t completion_code;
+	uint8_t type_count;
+	uint8_t types[];
+} __attribute__((packed));
+
 #ifdef __cplusplus
 }
 #endif

--- a/libmctp-cmds.h
+++ b/libmctp-cmds.h
@@ -17,7 +17,6 @@ struct mctp_ctrl_msg_hdr {
 	uint8_t ic_msg_type;
 	uint8_t rq_dgram_inst;
 	uint8_t command_code;
-	uint8_t completion_code;
 };
 
 #define MCTP_CTRL_HDR_MSG_TYPE	       0

--- a/libmctp-i2c.h
+++ b/libmctp-i2c.h
@@ -1,0 +1,31 @@
+#include <stdint.h>
+
+#include "libmctp.h"
+
+struct mctp_binding_i2c;
+
+typedef int (*mctp_i2c_tx_fn)(const void *buf, size_t len, void *ctx);
+
+/* Configures the i2c binding. */
+int mctp_i2c_setup(struct mctp_binding_i2c *i2c, uint8_t own_addr,
+		   mctp_i2c_tx_fn tx_fn, void *tx_ctx);
+void mctp_i2c_cleanup(struct mctp_binding_i2c *i2c);
+
+int mctp_i2c_set_address(struct mctp_binding_i2c *i2c, uint8_t own_addr);
+
+struct mctp_binding *mctp_binding_i2c_core(struct mctp_binding_i2c *i2c);
+
+int mctp_i2c_set_neighbour(struct mctp_binding_i2c *i2c, uint8_t eid,
+			   uint8_t addr);
+
+void mctp_i2c_rx(struct mctp_binding_i2c *i2c, const void *data, size_t len);
+int mctp_i2c_parse_hdr(const void *data, size_t len, uint8_t *src_addr,
+		       uint8_t *dest_addr, uint8_t *bytecount);
+void mctp_i2c_tx_poll(struct mctp_binding_i2c *i2c);
+
+/* Can be customised if needed */
+#ifndef I2C_BTU
+#define I2C_BTU MCTP_BTU
+#endif
+
+#define MCTP_I2C_PACKET_SIZE (MCTP_PACKET_SIZE(I2C_BTU) + 4)

--- a/libmctp-log.h
+++ b/libmctp-log.h
@@ -5,8 +5,23 @@
 
 /* libmctp-internal logging */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef MCTP_NOLOG
+
+__attribute__((format(printf, 2, 3))) static inline void
+mctp_prlog(int level __unused, const char *fmt __unused, ...)
+{
+}
+
+#else
+
 void mctp_prlog(int level, const char *fmt, ...)
 	__attribute__((format(printf, 2, 3)));
+
+#endif
 
 #ifndef pr_fmt
 #define pr_fmt(x) x

--- a/libmctp-serial.h
+++ b/libmctp-serial.h
@@ -26,8 +26,10 @@ int mctp_serial_open_path(struct mctp_binding_serial *serial, const char *path);
 void mctp_serial_open_fd(struct mctp_binding_serial *serial, int fd);
 
 /* direct function call IO */
-typedef int (*mctp_serial_tx_fn)(void *data, void *buf, size_t len)
-	__attribute__((warn_unused_result));
+typedef int
+	__attribute__((warn_unused_result)) (*mctp_serial_tx_fn)(void *data,
+								 void *buf,
+								 size_t len);
 void mctp_serial_set_tx_fn(struct mctp_binding_serial *serial,
 			   mctp_serial_tx_fn fn, void *data);
 int mctp_serial_rx(struct mctp_binding_serial *serial, const void *buf,

--- a/libmctp-sizes.h.in
+++ b/libmctp-sizes.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define MCTP_SIZEOF_STRUCT_MCTP @sizeof_struct_mctp@

--- a/libmctp-sizes.h.in
+++ b/libmctp-sizes.h.in
@@ -1,3 +1,5 @@
 #pragma once
 
 #define MCTP_SIZEOF_STRUCT_MCTP @sizeof_struct_mctp@
+/* sizeof(struct mctp_binding_i2c) */
+#define MCTP_SIZEOF_BINDING_I2C @sizeof_binding_i2c@

--- a/libmctp.h
+++ b/libmctp.h
@@ -52,25 +52,35 @@ struct mctp_hdr {
 struct mctp_pktbuf {
 	size_t start, end, size;
 	size_t mctp_hdr_off;
-	struct mctp_pktbuf *next;
+	bool alloc;
 	unsigned char data[];
 };
 
+#define MCTP_PKTBUF_SIZE(payload)                                              \
+	(MCTP_PACKET_SIZE(payload) + sizeof(struct mctp_pktbuf))
+
+struct mctp;
+struct mctp_bus;
 struct mctp_binding;
 
-struct mctp_pktbuf *mctp_pktbuf_alloc(struct mctp_binding *hw, size_t len);
+/* Initialise a mctp_pktbuf in static storage. Should not be freed.
+ * Storage must be sized to fit the binding,
+ * MCTP_PKTBUF_SIZE(binding->pkt_size + binding->pkt_header + binding->pkt_trailer) */
+struct mctp_pktbuf *mctp_pktbuf_init(struct mctp_binding *binding,
+				     void *storage);
+/* Allocate and initialise a mctp_pktbuf. Should be freed with
+ * mctp_pktbuf_free */
+struct mctp_pktbuf *mctp_pktbuf_alloc(struct mctp_binding *binding, size_t len);
 void mctp_pktbuf_free(struct mctp_pktbuf *pkt);
 struct mctp_hdr *mctp_pktbuf_hdr(struct mctp_pktbuf *pkt);
 void *mctp_pktbuf_data(struct mctp_pktbuf *pkt);
-size_t mctp_pktbuf_size(struct mctp_pktbuf *pkt);
+size_t mctp_pktbuf_size(const struct mctp_pktbuf *pkt);
 void *mctp_pktbuf_alloc_start(struct mctp_pktbuf *pkt, size_t size);
 void *mctp_pktbuf_alloc_end(struct mctp_pktbuf *pkt, size_t size);
 int mctp_pktbuf_push(struct mctp_pktbuf *pkt, const void *data, size_t len);
 void *mctp_pktbuf_pop(struct mctp_pktbuf *pkt, size_t len);
 
 /* MCTP core */
-struct mctp;
-struct mctp_bus;
 
 struct mctp *mctp_init(void);
 void mctp_set_max_message_size(struct mctp *mctp, size_t message_size);
@@ -106,13 +116,40 @@ typedef void (*mctp_rx_fn)(uint8_t src_eid, bool tag_owner, uint8_t msg_tag,
 
 int mctp_set_rx_all(struct mctp *mctp, mctp_rx_fn fn, void *data);
 
+/* Transmit a message.
+ * @msg: The message buffer to send. Must be suitable for
+ * free(), or the custom mctp_set_alloc_ops() m_msg_free.
+ * The mctp stack will take ownership of the buffer
+ * and release it when message transmission is complete or fails.
+ *
+ * If an asynchronous binding is being used, it will return -EBUSY if
+ * a message is already pending for transmission (msg will be freed as usual).
+ * Asynchronous users can test mctp_is_tx_ready() prior to sending.
+ */
+int mctp_message_tx_alloced(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
+			    uint8_t msg_tag, void *msg, size_t msg_len);
+
+/* Transmit a message.
+ * @msg: The message buffer to send. Ownership of this buffer
+ * remains with the caller (a copy is made internally with __mctp_msg_alloc).
+ *
+ * If an asynchronous binding is being used, it will return -EBUSY if
+ * a message is already pending for transmission.
+ * Asynchronous users can test mctp_is_tx_ready() prior to sending.
+ *
+ * This is equivalent to duplicating `msg` then calling mctp_message_tx_alloc().
+ */
 int mctp_message_tx(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
-		    uint8_t msg_tag, void *msg, size_t msg_len);
+		    uint8_t msg_tag, const void *msg, size_t msg_len);
+
+bool mctp_is_tx_ready(struct mctp *mctp, mctp_eid_t eid);
 
 /* hardware bindings */
 
 /**
  * @tx: Binding function to transmit one packet on the interface
+ * @tx_storage: A buffer for transmitting packets. Must be sized
+ * as MCTP_PKTBUF_SIZE(mtu).
  *      Return:
  *      * 0 - Success, pktbuf can be released
  *	* -EMSGSIZE - Packet exceeds binding MTU, pktbuf must be dropped
@@ -126,6 +163,7 @@ struct mctp_binding {
 	size_t pkt_size;
 	size_t pkt_header;
 	size_t pkt_trailer;
+	void *tx_storage;
 	int (*start)(struct mctp_binding *binding);
 	int (*tx)(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
 	mctp_rx_fn control_rx;
@@ -141,8 +179,12 @@ void mctp_binding_set_tx_enabled(struct mctp_binding *binding, bool enable);
 void mctp_bus_rx(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
 
 /* environment-specific allocation */
-void mctp_set_alloc_ops(void *(*alloc)(size_t), void (*free)(void *),
-			void *(realloc)(void *, size_t));
+void mctp_set_alloc_ops(void *(*m_alloc)(size_t), void (*m_free)(void *),
+			void *(*m_msg_alloc)(size_t, void *),
+			void (*m_msg_free)(void *, void *));
+/* Gets/sets context that will be passed to custom m_msg_ ops */
+void *mctp_get_alloc_ctx(struct mctp *mctp);
+void mctp_set_alloc_ctx(struct mctp *mctp, void *ctx);
 
 /* environment-specific logging */
 

--- a/libmctp.h
+++ b/libmctp.h
@@ -65,7 +65,7 @@ void *mctp_pktbuf_data(struct mctp_pktbuf *pkt);
 size_t mctp_pktbuf_size(struct mctp_pktbuf *pkt);
 void *mctp_pktbuf_alloc_start(struct mctp_pktbuf *pkt, size_t size);
 void *mctp_pktbuf_alloc_end(struct mctp_pktbuf *pkt, size_t size);
-int mctp_pktbuf_push(struct mctp_pktbuf *pkt, void *data, size_t len);
+int mctp_pktbuf_push(struct mctp_pktbuf *pkt, const void *data, size_t len);
 void *mctp_pktbuf_pop(struct mctp_pktbuf *pkt, size_t len);
 
 /* MCTP core */

--- a/libmctp.h
+++ b/libmctp.h
@@ -224,6 +224,15 @@ void mctp_set_log_custom(void (*fn)(int, const char *, va_list));
 #define MCTP_LOG_INFO	 6
 #define MCTP_LOG_DEBUG	 7
 
+/* Environment-specific time functionality */
+/* The `now` callback returns a timestamp in milliseconds.
+ * Timestamps should be monotonically increasing, and can have an arbitrary
+ * origin. (As long as returned timestamps aren't too close to UINT64_MAX, not
+ * a problem forany reasonable implementation). */
+void mctp_set_now_op(struct mctp *mctp, uint64_t (*now)(void *), void *ctx);
+/* Returns a timestamp in milliseconds */
+uint64_t mctp_now(struct mctp *mctp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libmctp.h
+++ b/libmctp.h
@@ -88,7 +88,7 @@ struct mctp *mctp_init(void);
 void mctp_destroy(struct mctp *mctp);
 
 /* Setup a MCTP instance */
-void mctp_setup(struct mctp *mctp);
+int mctp_setup(struct mctp *mctp, size_t struct_mctp_size);
 /* Release resource of a MCTP instance */
 void mctp_cleanup(struct mctp *mctp);
 

--- a/libmctp.h
+++ b/libmctp.h
@@ -11,6 +11,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <stdalign.h>
 
 typedef uint8_t mctp_eid_t;
 
@@ -58,6 +59,7 @@ struct mctp_pktbuf {
 
 #define MCTP_PKTBUF_SIZE(payload)                                              \
 	(MCTP_PACKET_SIZE(payload) + sizeof(struct mctp_pktbuf))
+#define PKTBUF_STORAGE_ALIGN __attribute((aligned(alignof(struct mctp_pktbuf))))
 
 struct mctp;
 struct mctp_bus;
@@ -65,7 +67,9 @@ struct mctp_binding;
 
 /* Initialise a mctp_pktbuf in static storage. Should not be freed.
  * Storage must be sized to fit the binding,
- * MCTP_PKTBUF_SIZE(binding->pkt_size + binding->pkt_header + binding->pkt_trailer) */
+ * MCTP_PKTBUF_SIZE(binding->pkt_size + binding->pkt_header + binding->pkt_trailer).
+ * storage must be aligned to alignof(struct mctp_pktbuf), 
+ * use PKTBUF_STORAGE_ALIGN macro */
 struct mctp_pktbuf *mctp_pktbuf_init(struct mctp_binding *binding,
 				     void *storage);
 /* Allocate and initialise a mctp_pktbuf. Should be freed with
@@ -175,7 +179,7 @@ bool mctp_is_tx_ready(struct mctp *mctp, mctp_eid_t eid);
 /**
  * @tx: Binding function to transmit one packet on the interface
  * @tx_storage: A buffer for transmitting packets. Must be sized
- * as MCTP_PKTBUF_SIZE(mtu).
+ * as MCTP_PKTBUF_SIZE(mtu) and 8 byte aligned.
  *      Return:
  *      * 0 - Success, pktbuf can be released
  *	* -EMSGSIZE - Packet exceeds binding MTU, pktbuf must be dropped

--- a/libmctp.h
+++ b/libmctp.h
@@ -82,13 +82,21 @@ void *mctp_pktbuf_pop(struct mctp_pktbuf *pkt, size_t len);
 
 /* MCTP core */
 
+/* Allocate and setup a MCTP instance */
 struct mctp *mctp_init(void);
+/* Cleanup and deallocate a MCTP instance from mctp_init() */
+void mctp_destroy(struct mctp *mctp);
+
+/* Setup a MCTP instance */
+void mctp_setup(struct mctp *mctp);
+/* Release resource of a MCTP instance */
+void mctp_cleanup(struct mctp *mctp);
+
 void mctp_set_max_message_size(struct mctp *mctp, size_t message_size);
 typedef void (*mctp_capture_fn)(struct mctp_pktbuf *pkt, bool outgoing,
 				void *user);
 void mctp_set_capture_handler(struct mctp *mctp, mctp_capture_fn fn,
 			      void *user);
-void mctp_destroy(struct mctp *mctp);
 
 /* Register a binding to the MCTP core, and creates a bus (populating
  * binding->bus).

--- a/libmctp.h
+++ b/libmctp.h
@@ -150,6 +150,22 @@ int mctp_message_tx_alloced(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
 int mctp_message_tx(struct mctp *mctp, mctp_eid_t eid, bool tag_owner,
 		    uint8_t msg_tag, const void *msg, size_t msg_len);
 
+/* Transmit a request message.
+ * @msg: The message buffer to send. Must be suitable for
+ * free(), or the custom mctp_set_alloc_ops() m_msg_free.
+ *
+ * A tag with Tag Owner bit set will allocated for the sent message,
+ * and returned to the caller (TO bit is unset in the returned @alloc_msg_tag).
+ * alloc_msg_tag may be NULL to ignore the returned tag.
+ * If no tags are spare -EBUSY will be returned.
+ *
+ * If an asynchronous binding is being used, it will return -EBUSY if
+ * a message is already pending for transmission (msg will be freed).
+ * Asynchronous users can test mctp_is_tx_ready() prior to sending.
+ */
+int mctp_message_tx_request(struct mctp *mctp, mctp_eid_t eid, void *msg,
+			    size_t msg_len, uint8_t *alloc_msg_tag);
+
 bool mctp_is_tx_ready(struct mctp *mctp, mctp_eid_t eid);
 
 /* hardware bindings */

--- a/libmctp.h
+++ b/libmctp.h
@@ -110,6 +110,8 @@ int mctp_register_bus(struct mctp *mctp, struct mctp_binding *binding,
 
 void mctp_unregister_bus(struct mctp *mctp, struct mctp_binding *binding);
 
+int mctp_bus_set_eid(struct mctp_binding *binding, mctp_eid_t eid);
+
 /* Create a simple bidirectional bridge between busses.
  *
  * In this mode, the MCTP stack is initialised as a bridge. There is no EID
@@ -232,6 +234,14 @@ void mctp_set_log_custom(void (*fn)(int, const char *, va_list));
 void mctp_set_now_op(struct mctp *mctp, uint64_t (*now)(void *), void *ctx);
 /* Returns a timestamp in milliseconds */
 uint64_t mctp_now(struct mctp *mctp);
+
+int mctp_control_handler_enable(struct mctp *mctp);
+void mctp_control_handler_disable(struct mctp *mctp);
+
+/* Add/remove message types to be reported by Get MCTP Version Support.
+ * Control type is added automatically for the control handler */
+int mctp_control_add_type(struct mctp *mctp, uint8_t msg_type);
+void mctp_control_remove_type(struct mctp *mctp, uint8_t msg_type);
 
 #ifdef __cplusplus
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project(
-    'libmctp', 'c',
+    'libmctp',
+    'c',
     meson_version: '>= 1.1',
     version: '0.11',
     default_options: [
@@ -11,44 +12,22 @@ project(
     ],
 )
 
-sources = [
-     'core.c',
-     'alloc.c',
-     'control.c',
-]
+sources = ['core.c', 'alloc.c', 'control.c']
 
-headers = [
-    'libmctp.h',
-]
+headers = ['libmctp.h']
 
-serial_sources = [
-    'serial.c',
-    'crc-16-ccitt.c',
-]
+serial_sources = ['serial.c', 'crc-16-ccitt.c']
 
-serial_headers = [
-    'libmctp-serial.h'
-]
+serial_headers = ['libmctp-serial.h']
 
-astlpc_sources = [
-    'astlpc.c',
-    'crc32.c',
-]
+astlpc_sources = ['astlpc.c', 'crc32.c']
 
-astlpc_headers = [
-    'libmctp-astlpc.h',
-]
+astlpc_headers = ['libmctp-astlpc.h']
 
-i2c_sources = [
-    'i2c.c',
-]
+i2c_sources = ['i2c.c']
 
-i2c_headers = [
-    'libmctp-i2c.h',
-]
-control_sources = [
-    'control.c',
-]
+i2c_headers = ['libmctp-i2c.h']
+control_sources = ['control.c']
 
 libmctp_sources = sources
 libmctp_headers = headers
@@ -72,41 +51,48 @@ endif
 compiler = meson.get_compiler('c')
 
 if not get_option('custom_alloc') and get_option('default_alloc').require(
-    compiler.links('''
+    compiler.links(
+        '''
         #include <stdlib.h>
         void main()
         {
             free(malloc(4096));
         }
-    ''')).allowed()
-    add_project_arguments('-DMCTP_DEFAULT_ALLOC', language : 'c')
+    ''',
+    ),
+).allowed()
+    add_project_arguments('-DMCTP_DEFAULT_ALLOC', language: 'c')
 endif
 
 if get_option('custom_alloc')
-    add_project_arguments('-DMCTP_CUSTOM_ALLOC', language : 'c')
+    add_project_arguments('-DMCTP_CUSTOM_ALLOC', language: 'c')
 endif
 
 if get_option('nolog')
-    add_project_arguments('-DMCTP_NOLOG', language : 'c')
+    add_project_arguments('-DMCTP_NOLOG', language: 'c')
 else
     libmctp_sources += ['log.c']
 endif
 
 feat_fileio = get_option('fileio').require(
-    compiler.links('''
+    compiler.links(
+        '''
         #include <poll.h>
         #include <unistd.h>
         void main()
         {
             poll(NULL, 0, -1);
         }
-    '''))
+    ''',
+    ),
+)
 if feat_fileio.allowed()
-    add_project_arguments('-DMCTP_HAVE_FILEIO', language : 'c')
+    add_project_arguments('-DMCTP_HAVE_FILEIO', language: 'c')
 endif
 
 if get_option('syslog').require(
-    compiler.links('''
+    compiler.links(
+        '''
         #include <stdarg.h>
         #include <syslog.h>
         void check_vsyslog(int level, const char *fmt, ...)
@@ -120,12 +106,15 @@ if get_option('syslog').require(
         {
             check_vsyslog(0, "\n");
         }
-        ''')).allowed()
-    add_project_arguments('-DMCTP_HAVE_SYSLOG', language : 'c')
+        ''',
+    ),
+).allowed()
+    add_project_arguments('-DMCTP_HAVE_SYSLOG', language: 'c')
 endif
 
 if get_option('stdio').require(
-    compiler.links('''
+    compiler.links(
+        '''
         #include <stdarg.h>
         #include <stdio.h>
         void check_vsyslog(const char *fmt, ...)
@@ -139,8 +128,10 @@ if get_option('stdio').require(
         {
             check_vsyslog("\n");
         }
-        ''')).allowed()
-    add_project_arguments('-DMCTP_HAVE_STDIO', language : 'c')
+        ''',
+    ),
+).allowed()
+    add_project_arguments('-DMCTP_HAVE_STDIO', language: 'c')
 endif
 
 # pcap is necessary for mctp-demux-daemon to be functional
@@ -150,7 +141,8 @@ systemd_dep = dependency('systemd', required: false)
 libsystemd_dep = dependency('libsystemd', required: false)
 
 libmctp_include_dir = include_directories('.', is_system: true)
-libmctp = library('mctp',
+libmctp = library(
+    'mctp',
     libmctp_sources,
     include_directories: libmctp_include_dir,
     version: meson.project_version(),
@@ -164,7 +156,8 @@ if systemd_dep.found()
     install_data('systemd/system/mctp-demux.socket', install_dir: unitdir)
 endif
 
-import('pkgconfig').generate(libmctp,
+import('pkgconfig').generate(
+    libmctp,
     name: 'libmctp',
     description: 'MCTP protocol implementation',
     version: meson.project_version(),
@@ -177,19 +170,24 @@ libmctp_dep = declare_dependency(
 
 # TODO: these should depend on the -internal.h headers so they rebuild
 # on changes, unclear how to do that.
-sizeof_mctp = compiler.sizeof('struct mctp',
+sizeof_mctp = compiler.sizeof(
+    'struct mctp',
     include_directories: libmctp_include_dir,
-    prefix: '#include "core-internal.h"')
-sizeof_binding_i2c = compiler.sizeof('struct mctp_binding_i2c',
+    prefix: '#include "core-internal.h"',
+)
+sizeof_binding_i2c = compiler.sizeof(
+    'struct mctp_binding_i2c',
     include_directories: libmctp_include_dir,
-    prefix: '#include "i2c-internal.h"')
-sizes_h = configure_file(configuration: {
+    prefix: '#include "i2c-internal.h"',
+)
+sizes_h = configure_file(
+    configuration: {
         'sizeof_struct_mctp': sizeof_mctp,
         'sizeof_binding_i2c': sizeof_binding_i2c,
     },
     input: 'libmctp-sizes.h.in',
     output: 'libmctp-sizes.h',
-    )
+)
 install_headers(sizes_h)
 
 if feat_fileio.allowed()

--- a/meson.build
+++ b/meson.build
@@ -64,9 +64,16 @@ if get_option('default_alloc').require(
     add_project_arguments('-DMCTP_DEFAULT_ALLOC', language : 'c')
 endif
 
-if get_option('fileio').require(
-    compiler.check_header('unistd.h') and compiler.check_header('fcntl.h')
-    ).allowed()
+feat_fileio = get_option('fileio').require(
+    compiler.links('''
+        #include <poll.h>
+        #include <unistd.h>
+        void main()
+        {
+            poll(NULL, 0, -1);
+        }
+    '''))
+if feat_fileio.allowed()
     add_project_arguments('-DMCTP_HAVE_FILEIO', language : 'c')
 endif
 
@@ -140,7 +147,9 @@ libmctp_dep = declare_dependency(
     link_with: libmctp,
 )
 
-subdir('utils')
+if feat_fileio.allowed()
+    subdir('utils')
+endif
 
 if get_option('tests').allowed()
     subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -156,6 +156,17 @@ libmctp_dep = declare_dependency(
     link_with: libmctp,
 )
 
+sizeof_mctp = compiler.sizeof('struct mctp',
+    include_directories: libmctp_include_dir,
+    prefix: '#include "core-internal.h"')
+sizes_h = configure_file(configuration: {
+        'sizeof_struct_mctp': sizeof_mctp,
+    },
+    input: 'libmctp-sizes.h.in',
+    output: 'libmctp-sizes.h',
+    )
+install_headers(sizes_h)
+
 if feat_fileio.allowed()
     subdir('utils')
 endif

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ project(
 sources = [
      'core.c',
      'alloc.c',
+     'control.c',
 ]
 
 headers = [
@@ -45,6 +46,9 @@ i2c_sources = [
 i2c_headers = [
     'libmctp-i2c.h',
 ]
+control_sources = [
+    'control.c',
+]
 
 libmctp_sources = sources
 libmctp_headers = headers
@@ -60,6 +64,9 @@ endif
 if get_option('bindings').contains('i2c')
     libmctp_sources += i2c_sources
     libmctp_headers += i2c_headers
+endif
+if get_option('control')
+    libmctp_sources += control_sources
 endif
 
 compiler = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,7 @@ endif
 
 compiler = meson.get_compiler('c')
 
-if get_option('default_alloc').require(
+if not get_option('custom_alloc') and get_option('default_alloc').require(
     compiler.links('''
         #include <stdlib.h>
         void main()
@@ -62,6 +62,10 @@ if get_option('default_alloc').require(
         }
     ''')).allowed()
     add_project_arguments('-DMCTP_DEFAULT_ALLOC', language : 'c')
+endif
+
+if get_option('custom_alloc')
+    add_project_arguments('-DMCTP_CUSTOM_ALLOC', language : 'c')
 endif
 
 feat_fileio = get_option('fileio').require(

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,147 @@
+project(
+    'libmctp', 'c',
+    meson_version: '>= 1.1',
+    version: '0.11',
+    default_options: [
+        'debug=true',
+        'optimization=g',
+        'warning_level=2',
+        'werror=true',
+        'tests=' + (meson.is_subproject() ? 'disabled' : 'enabled'),
+    ],
+)
+
+sources = [
+     'core.c',
+     'alloc.c',
+     'log.c',
+]
+
+headers = [
+    'libmctp.h',
+]
+
+serial_sources = [
+    'serial.c',
+    'crc-16-ccitt.c',
+]
+
+serial_headers = [
+    'libmctp-serial.h'
+]
+
+astlpc_sources = [
+    'astlpc.c',
+    'crc32.c',
+]
+
+astlpc_headers = [
+    'libmctp-astlpc.h',
+]
+
+libmctp_sources = sources
+libmctp_headers = headers
+
+if get_option('bindings').contains('serial')
+    libmctp_sources += serial_sources
+    libmctp_headers += serial_headers
+endif
+if get_option('bindings').contains('astlpc')
+    libmctp_sources += astlpc_sources
+    libmctp_headers += astlpc_headers
+endif
+
+compiler = meson.get_compiler('c')
+
+if get_option('default_alloc').require(
+    compiler.links('''
+        #include <stdlib.h>
+        void main()
+        {
+            free(malloc(4096));
+        }
+    ''')).allowed()
+    add_project_arguments('-DMCTP_DEFAULT_ALLOC', language : 'c')
+endif
+
+if get_option('fileio').require(
+    compiler.check_header('unistd.h') and compiler.check_header('fcntl.h')
+    ).allowed()
+    add_project_arguments('-DMCTP_HAVE_FILEIO', language : 'c')
+endif
+
+if get_option('syslog').require(
+    compiler.links('''
+        #include <stdarg.h>
+        #include <syslog.h>
+        void check_vsyslog(int level, const char *fmt, ...)
+        {
+            va_list ap;
+            va_start(ap, fmt);
+            vsyslog(0, fmt, ap);
+            va_end(ap);
+        }
+        void main()
+        {
+            check_vsyslog(0, "\n");
+        }
+        ''')).allowed()
+    add_project_arguments('-DMCTP_HAVE_SYSLOG', language : 'c')
+endif
+
+if get_option('stdio').require(
+    compiler.links('''
+        #include <stdarg.h>
+        #include <stdio.h>
+        void check_vsyslog(const char *fmt, ...)
+        {
+            va_list ap;
+            va_start(ap, fmt);
+            vprintf(fmt, ap);
+            va_end(ap);
+        }
+        void main()
+        {
+            check_vsyslog("\n");
+        }
+        ''')).allowed()
+    add_project_arguments('-DMCTP_HAVE_STDIO', language : 'c')
+endif
+
+# pcap is necessary for mctp-demux-daemon to be functional
+pcap_dep = dependency('libpcap', required: false)
+
+systemd_dep = dependency('systemd', required: false)
+libsystemd_dep = dependency('libsystemd', required: false)
+
+libmctp_include_dir = include_directories('.', is_system: true)
+libmctp = library('mctp',
+    libmctp_sources,
+    include_directories: libmctp_include_dir,
+    version: meson.project_version(),
+    install: true,
+)
+install_headers(libmctp_headers)
+
+if systemd_dep.found()
+    unitdir = systemd_dep.get_variable(pkgconfig: 'systemdsystemunitdir')
+    install_data('systemd/system/mctp-demux.service', install_dir: unitdir)
+    install_data('systemd/system/mctp-demux.socket', install_dir: unitdir)
+endif
+
+import('pkgconfig').generate(libmctp,
+    name: 'libmctp',
+    description: 'MCTP protocol implementation',
+    version: meson.project_version(),
+)
+
+libmctp_dep = declare_dependency(
+    include_directories: libmctp_include_dir,
+    link_with: libmctp,
+)
+
+subdir('utils')
+
+if get_option('tests').allowed()
+    subdir('tests')
+endif

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,14 @@ astlpc_headers = [
     'libmctp-astlpc.h',
 ]
 
+i2c_sources = [
+    'i2c.c',
+]
+
+i2c_headers = [
+    'libmctp-i2c.h',
+]
+
 libmctp_sources = sources
 libmctp_headers = headers
 
@@ -48,6 +56,10 @@ endif
 if get_option('bindings').contains('astlpc')
     libmctp_sources += astlpc_sources
     libmctp_headers += astlpc_headers
+endif
+if get_option('bindings').contains('i2c')
+    libmctp_sources += i2c_sources
+    libmctp_headers += i2c_headers
 endif
 
 compiler = meson.get_compiler('c')
@@ -156,11 +168,17 @@ libmctp_dep = declare_dependency(
     link_with: libmctp,
 )
 
+# TODO: these should depend on the -internal.h headers so they rebuild
+# on changes, unclear how to do that.
 sizeof_mctp = compiler.sizeof('struct mctp',
     include_directories: libmctp_include_dir,
     prefix: '#include "core-internal.h"')
+sizeof_binding_i2c = compiler.sizeof('struct mctp_binding_i2c',
+    include_directories: libmctp_include_dir,
+    prefix: '#include "i2c-internal.h"')
 sizes_h = configure_file(configuration: {
         'sizeof_struct_mctp': sizeof_mctp,
+        'sizeof_binding_i2c': sizeof_binding_i2c,
     },
     input: 'libmctp-sizes.h.in',
     output: 'libmctp-sizes.h',

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,6 @@ project(
 sources = [
      'core.c',
      'alloc.c',
-     'log.c',
 ]
 
 headers = [
@@ -66,6 +65,12 @@ endif
 
 if get_option('custom_alloc')
     add_project_arguments('-DMCTP_CUSTOM_ALLOC', language : 'c')
+endif
+
+if get_option('nolog')
+    add_project_arguments('-DMCTP_NOLOG', language : 'c')
+else
+    libmctp_sources += ['log.c']
 endif
 
 feat_fileio = get_option('fileio').require(

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,20 @@ else
     libmctp_sources += ['log.c']
 endif
 
+option_args = [
+    '-DMCTP_MAX_MESSAGE_SIZE=@0@'.format(get_option('max_message_size')),
+    '-DMCTP_REASSEMBLY_CTXS=@0@'.format(get_option('reassembly_contexts')),
+    '-DMCTP_REQ_TAGS=@0@'.format(get_option('request_tags')),
+    '-DMCTP_DEFAULT_CLOCK_GETTIME=@0@'.format(
+        get_option('default_clock_gettime').to_int(),
+    ),
+    '-DMCTP_CONTROL_HANDLER=@0@'.format(get_option('control').to_int()),
+    '-DI2C_BTU=@0@'.format(get_option('i2c_mtu')),
+    '-DMCTP_I2C_NEIGH_COUNT=@0@'.format(get_option('i2c_neigh_count')),
+]
+
+add_project_arguments(option_args, language: 'c')
+
 feat_fileio = get_option('fileio').require(
     compiler.links(
         '''
@@ -173,11 +187,13 @@ libmctp_dep = declare_dependency(
 sizeof_mctp = compiler.sizeof(
     'struct mctp',
     include_directories: libmctp_include_dir,
+    args: option_args,
     prefix: '#include "core-internal.h"',
 )
 sizeof_binding_i2c = compiler.sizeof(
     'struct mctp_binding_i2c',
     include_directories: libmctp_include_dir,
+    args: option_args,
     prefix: '#include "i2c-internal.h"',
 )
 sizes_h = configure_file(

--- a/meson.build
+++ b/meson.build
@@ -151,7 +151,7 @@ libmctp = library(
 install_headers(libmctp_headers)
 
 if systemd_dep.found()
-    unitdir = systemd_dep.get_variable(pkgconfig: 'systemdsystemunitdir')
+    unitdir = systemd_dep.get_variable(pkgconfig: 'systemd_system_unit_dir')
     install_data('systemd/system/mctp-demux.service', install_dir: unitdir)
     install_data('systemd/system/mctp-demux.socket', install_dir: unitdir)
 endif

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,33 @@
+option(
+    'tests',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Build tests'
+)
+option(
+    'bindings',
+    type: 'array',
+    description: 'Bindings to include',
+    choices: ['serial', 'astlpc'],
+    value: ['serial', 'astlpc'],
+)
+option(
+    'default_alloc',
+    type: 'feature',
+    description: 'Use libc malloc and free for heap memory',
+)
+option(
+    'stdio',
+    type: 'feature',
+    description: 'Support logging to stdio',
+)
+option(
+    'fileio',
+    type: 'feature',
+    description: 'Support interfaces based on file-descriptors',
+)
+option(
+    'syslog',
+    type: 'feature',
+    description: 'Support logging to syslog',
+)

--- a/meson.options
+++ b/meson.options
@@ -31,3 +31,9 @@ option(
     type: 'feature',
     description: 'Support logging to syslog',
 )
+option(
+    'custom_alloc',
+    type: 'boolean',
+    value: false,
+    description: 'Use fixed application-provided allocators',
+)

--- a/meson.options
+++ b/meson.options
@@ -37,3 +37,9 @@ option(
     value: false,
     description: 'Use fixed application-provided allocators',
 )
+option(
+    'nolog',
+    type: 'boolean',
+    value: false,
+    description: 'Don\'t include any logging functionality',
+)

--- a/meson.options
+++ b/meson.options
@@ -43,3 +43,9 @@ option(
     value: false,
     description: 'Don\'t include any logging functionality',
 )
+option(
+    'control',
+    type: 'boolean',
+    value: true,
+    description: 'Include MCTP control protocol handler',
+)

--- a/meson.options
+++ b/meson.options
@@ -1,9 +1,4 @@
-option(
-    'tests',
-    type: 'feature',
-    value: 'enabled',
-    description: 'Build tests'
-)
+option('tests', type: 'feature', value: 'enabled', description: 'Build tests')
 option(
     'bindings',
     type: 'array',
@@ -16,21 +11,13 @@ option(
     type: 'feature',
     description: 'Use libc malloc and free for heap memory',
 )
-option(
-    'stdio',
-    type: 'feature',
-    description: 'Support logging to stdio',
-)
+option('stdio', type: 'feature', description: 'Support logging to stdio')
 option(
     'fileio',
     type: 'feature',
     description: 'Support interfaces based on file-descriptors',
 )
-option(
-    'syslog',
-    type: 'feature',
-    description: 'Support logging to syslog',
-)
+option('syslog', type: 'feature', description: 'Support logging to syslog')
 option(
     'custom_alloc',
     type: 'boolean',

--- a/meson.options
+++ b/meson.options
@@ -8,8 +8,8 @@ option(
     'bindings',
     type: 'array',
     description: 'Bindings to include',
-    choices: ['serial', 'astlpc'],
-    value: ['serial', 'astlpc'],
+    choices: ['serial', 'astlpc', 'i2c'],
+    value: ['serial', 'astlpc', 'i2c'],
 )
 option(
     'default_alloc',

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,3 @@
-option('tests', type: 'feature', value: 'enabled', description: 'Build tests')
 option(
     'bindings',
     type: 'array',
@@ -7,17 +6,11 @@ option(
     value: ['serial', 'astlpc', 'i2c'],
 )
 option(
-    'default_alloc',
-    type: 'feature',
-    description: 'Use libc malloc and free for heap memory',
+    'control',
+    type: 'boolean',
+    value: true,
+    description: 'Include MCTP control protocol handler',
 )
-option('stdio', type: 'feature', description: 'Support logging to stdio')
-option(
-    'fileio',
-    type: 'feature',
-    description: 'Support interfaces based on file-descriptors',
-)
-option('syslog', type: 'feature', description: 'Support logging to syslog')
 option(
     'custom_alloc',
     type: 'boolean',
@@ -25,14 +18,56 @@ option(
     description: 'Use fixed application-provided allocators',
 )
 option(
+    'default_alloc',
+    type: 'feature',
+    description: 'Use libc malloc and free for heap memory',
+)
+option(
+    'default_clock_gettime',
+    type: 'boolean',
+    value: true,
+    description: 'Use clock_gettime() for time',
+)
+option(
+    'fileio',
+    type: 'feature',
+    description: 'Support interfaces based on file-descriptors',
+)
+option(
     'nolog',
     type: 'boolean',
     value: false,
     description: 'Don\'t include any logging functionality',
 )
+option('stdio', type: 'feature', description: 'Support logging to stdio')
+option('syslog', type: 'feature', description: 'Support logging to syslog')
+option('tests', type: 'feature', value: 'enabled', description: 'Build tests')
+
+
 option(
-    'control',
-    type: 'boolean',
-    value: true,
-    description: 'Include MCTP control protocol handler',
+    'max_message_size',
+    type: 'integer',
+    value: 65536,
+    description: 'Maximum message size',
+)
+option(
+    'reassembly_contexts',
+    type: 'integer',
+    value: 16,
+    description: 'Number of concurrent reassembly contexts',
+)
+option(
+    'request_tags',
+    type: 'integer',
+    value: 16,
+    description: 'Number of outbound request tags',
+)
+
+
+option('i2c_mtu', type: 'integer', value: 64, description: 'I2C packet MTU')
+option(
+    'i2c_neigh_count',
+    type: 'integer',
+    value: 4,
+    description: 'I2C neighbour table size',
 )

--- a/range.h
+++ b/range.h
@@ -1,26 +1,12 @@
 #ifndef _RANGE_H
 #define _RANGE_H
 
-#ifndef typeof
-#define typeof __typeof__
-#endif
-
 #ifndef MIN
-#define MIN(a, b)                                                              \
-	({                                                                     \
-		typeof(a) _a = a;                                              \
-		typeof(b) _b = b;                                              \
-		_a < _b ? _a : _b;                                             \
-	})
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
 #ifndef MAX
-#define MAX(a, b)                                                              \
-	({                                                                     \
-		typeof(a) _a = a;                                              \
-		typeof(b) _b = b;                                              \
-		_a > _b ? _a : _b;                                             \
-	})
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
 #endif

--- a/serial.c
+++ b/serial.c
@@ -17,7 +17,7 @@
 #include <poll.h>
 #include <unistd.h>
 #else
-static const size_t write(int fd, void *buf, size_t len)
+static const size_t write(int fd, const void *buf, size_t len)
 {
 	return -1;
 }

--- a/serial.c
+++ b/serial.c
@@ -44,7 +44,7 @@ struct mctp_binding_serial {
 	/* receive buffer and state */
 	uint8_t rxbuf[1024];
 	struct mctp_pktbuf *rx_pkt;
-	uint8_t rx_storage[MCTP_PKTBUF_SIZE(SERIAL_BTU)];
+	uint8_t rx_storage[MCTP_PKTBUF_SIZE(SERIAL_BTU)] PKTBUF_STORAGE_ALIGN;
 	uint8_t rx_exp_len;
 	uint16_t rx_fcs;
 	uint16_t rx_fcs_calc;
@@ -62,7 +62,7 @@ struct mctp_binding_serial {
 	/* temporary transmit buffer */
 	uint8_t txbuf[256];
 	/* used by the MCTP stack */
-	uint8_t tx_storage[MCTP_PKTBUF_SIZE(SERIAL_BTU)];
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(SERIAL_BTU)] PKTBUF_STORAGE_ALIGN;
 };
 
 #define binding_to_serial(b)                                                   \

--- a/serial.c
+++ b/serial.c
@@ -317,7 +317,7 @@ static void mctp_rx_consume(struct mctp_binding_serial *serial, const void *buf,
 	size_t i;
 
 	for (i = 0; i < len; i++)
-		mctp_rx_consume_one(serial, *(uint8_t *)(buf + i));
+		mctp_rx_consume_one(serial, ((const uint8_t *)buf)[i]);
 }
 
 #ifdef MCTP_HAVE_FILEIO
@@ -330,7 +330,8 @@ int mctp_serial_read(struct mctp_binding_serial *serial)
 		return -1;
 
 	if (len < 0) {
-		mctp_prerr("can't read from serial device: %m");
+		mctp_prerr("can't read from serial device: %s",
+			   strerror(errno));
 		return -1;
 	}
 
@@ -353,7 +354,7 @@ int mctp_serial_open_path(struct mctp_binding_serial *serial,
 {
 	serial->fd = open(device, O_RDWR);
 	if (serial->fd < 0)
-		mctp_prerr("can't open device %s: %m", device);
+		mctp_prerr("can't open device %s: %s", device, strerror(errno));
 
 	return 0;
 }

--- a/serial.c
+++ b/serial.c
@@ -89,7 +89,7 @@ struct mctp_serial_trailer {
  * @dst: An opaque object to pass as state to fn
  * @src: A pointer to the buffer of data to copy to dst
  * @len: The length of the data pointed to by src
- * @return: 0 on succes, negative error code on failure
+ * @return: 0 on success, negative error code on failure
  *
  * Pre-condition: fn returns a write count or a negative error code
  * Post-condition: All bytes written or an error has occurred

--- a/tests/fuzz/fuzz-build.py
+++ b/tests/fuzz/fuzz-build.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# Builds fuzzing variants. Run this from the toplevel directory.
+# Beware this will wipe build directories.
+
+# Requires honggfuzz and afl++ installed
+
+# Builds are:
+# * AFL (normal, asan, cmplog)
+# * honggfuzz (asan, msan, ubsan)
+# * -O0, with coverage
+
+import os
+import subprocess
+
+# reduce warning level since tests since gtest is noisy
+BASE_MESONFLAGS = "-Dwarning_level=2 -Ddefault_library=static --wipe".split()
+FUZZ_PROGRAMS = ["tests/fuzz/i2c-fuzz"]
+
+
+def build(
+    build_dir: str,
+    cc: str = None,
+    cxx: str = None,
+    cflags="",
+    cxxflags="",
+    opt="3",
+    env={},
+    mesonflags=[],
+):
+    env = os.environ | env
+    env["CFLAGS"] = cflags
+    env["CXXFLAGS"] = cxxflags
+
+    # Meson sets CC="ccache cc" by default, but ccache removes -fprofile-arcs
+    # so coverage breaks (ccache #1531). Prevent that by setting CC/CXX.
+    env["CC"] = cc if cc else "cc"
+    env["CXX"] = cxx if cxx else "c++"
+
+    meson_cmd = ["meson"] + BASE_MESONFLAGS + mesonflags
+    meson_cmd += [f"-Doptimization={opt}"]
+    meson_cmd += [build_dir]
+    subprocess.run(meson_cmd, env=env, check=True)
+
+    ninja_cmd = ["ninja", "-C", build_dir] + FUZZ_PROGRAMS
+    subprocess.run(ninja_cmd, env=env, check=True)
+
+
+def build_afl():
+    env = {
+        # seems to be required for afl-clang-lto?
+        "AFL_REAL_LD": "ld.lld",
+    }
+    cc = "afl-clang-lto"
+    cxx = "afl-clang-lto++"
+
+    # normal
+    build("bfuzz", cc=cc, cxx=cxx, env=env)
+    # ASAN
+    build(
+        "bfuzzasan",
+        cc=cc,
+        cxx=cxx,
+        mesonflags=["-Db_sanitize=address"],
+        env=env,
+    )
+    # cmplog
+    build("bcmplog", cc=cc, cxx=cxx, env={"AFL_LLVM_CMPLOG": "1"} | env)
+
+
+def main():
+    # No profiling, has coverage
+    build(
+        "bnoopt",
+        cflags="-fprofile-abs-path",
+        cxxflags="-fprofile-abs-path",
+        opt="0",
+        mesonflags=["-Db_coverage=true"],
+    )
+
+    # AFL
+    build_afl()
+
+    # Honggfuzz
+    # asan by default
+    build(
+        "bhf",
+        cc="hfuzz-clang",
+        cxx="hfuzz-clang++",
+        env={"HFUZZ_CC_ASAN": "1"},
+    )
+    # msan
+    build(
+        "bhf-msan",
+        cc="hfuzz-clang",
+        cxx="hfuzz-clang++",
+        env={"HFUZZ_CC_MSAN": "1"},
+    )
+    # ubsan
+    build(
+        "bhf-ubsan",
+        cc="hfuzz-clang",
+        cxx="hfuzz-clang++",
+        env={"HFUZZ_CC_UBSAN": "1"},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fuzz/fuzz-coverage.py
+++ b/tests/fuzz/fuzz-coverage.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+# usage: fuzz-coverage.py [-h] corpus program srcdir builddir outdir
+
+# Runs corpus (directory of testcases) against a program
+# built with coverage, and produces a html report.
+
+# The program should be built with --coverage -fprofile-abs-path
+# -O0 may make the html report more legible?
+
+# Requires lcov and https://github.com/mozilla/grcov
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(args):
+    corpus = Path(args.corpus)
+    outdir = Path(args.outdir)
+
+    for c in Path(args.builddir).glob("**/*.gcda"):
+        print(f"Removed old coverage {c}", file=sys.stderr)
+        c.unlink()
+
+    print("Running corpus", file=sys.stderr)
+    for c in corpus.glob("*"):
+        c = c.open("rb").read()
+        subprocess.run([args.program], input=c)
+
+    print("Running grcov", file=sys.stderr)
+    outdir.mkdir(parents=True, exist_ok=True)
+    coverage_paths = [args.builddir]
+    lcov_file = outdir / "lcov.info"
+
+    subprocess.run(
+        [
+            "grcov",
+            "-b",
+            args.program,
+            "-o",
+            lcov_file,
+            "-t",
+            "lcov",
+            "-s",
+            args.srcdir,
+        ]
+        + coverage_paths,
+        check=True,
+    )
+
+    print("Running genhtml", file=sys.stderr)
+    subprocess.run(
+        [
+            "genhtml",
+            "-o",
+            outdir,
+            "--show-details",
+            "--highlight",
+            "--ignore-errors",
+            "source",
+            "--ignore-errors",
+            "unmapped",
+            "--legend",
+            lcov_file,
+        ],
+        check=True,
+    )
+
+    html = outdir / "index.html"
+    print(f"\n\nOutput is file://{html.absolute()}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("corpus", type=str, help="Corpus directory")
+    parser.add_argument("program", type=str, help="Target Program")
+    parser.add_argument("srcdir", type=str, help="Source directory")
+    parser.add_argument("builddir", type=str)
+    parser.add_argument("outdir", type=str)
+    args = parser.parse_args()
+
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fuzz/i2c-fuzz.c
+++ b/tests/fuzz/i2c-fuzz.c
@@ -1,0 +1,311 @@
+#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <errno.h>
+#include <endian.h>
+
+#include "compiler.h"
+#include "libmctp.h"
+#include "libmctp-i2c.h"
+#include "libmctp-sizes.h"
+#include "libmctp-alloc.h"
+
+#if NDEBUG
+static_assert(0, "fuzzing shouldn't build with NDEBUG");
+#endif
+
+/* Limits memory used in tx path */
+#define MAX_SEND 600
+
+/* Avoids wasting time traversing unreachable sizes */
+#define MAX_RECEIVE 30
+
+static const size_t FUZZCTRL_SIZE = 0x400;
+
+static const uint8_t RX_CHANCE = 90;
+static const uint8_t TX_BUSY_CHANCE = 3;
+
+static const uint8_t OWN_I2C_ADDR = 0x20;
+static const uint8_t OWN_EID = 123;
+
+/* time step in milliseconds */
+static const uint32_t MAX_TIME_STEP = 15000;
+
+struct fuzz_buf {
+	size_t len;
+	size_t pos;
+	const uint8_t *data;
+};
+
+struct fuzz_ctx {
+	struct fuzz_buf *ctrl;
+	struct fuzz_buf *input;
+
+	struct mctp_binding_i2c *i2c;
+	struct mctp *mctp;
+
+	uint64_t now;
+
+	bool done;
+};
+
+static struct fuzz_buf *fuzz_buf_new(const void *data, size_t len)
+{
+	struct fuzz_buf *buf = malloc(sizeof(struct fuzz_buf));
+	buf->pos = 0;
+	buf->len = len;
+	buf->data = data;
+	return buf;
+}
+
+static const void *fuzz_buf_extract(struct fuzz_buf *buf, size_t len)
+{
+	if (buf->pos + len > buf->len) {
+		return NULL;
+	}
+
+	const void *ret = &buf->data[buf->pos];
+	buf->pos += len;
+	return ret;
+}
+
+/* Returns true on success */
+static bool fuzz_buf_extract_u32(struct fuzz_buf *buf, uint32_t *ret)
+{
+	const void *r = fuzz_buf_extract(buf, sizeof(uint32_t));
+	if (!r) {
+		return false;
+	}
+
+	uint32_t v;
+	memcpy(&v, r, sizeof(v));
+	*ret = be32toh(v);
+	return true;
+}
+
+/* Returns true with roughly `percent` chance */
+static bool fuzz_chance(struct fuzz_ctx *ctx, uint8_t percent)
+{
+	assert(percent <= 100);
+
+	const uint8_t *v = fuzz_buf_extract(ctx->ctrl, sizeof(uint8_t));
+	if (!v) {
+		return false;
+	}
+
+	uint8_t cutoff = (uint32_t)percent * UINT8_MAX / 100;
+	return *v <= cutoff;
+}
+
+static int fuzz_i2c_tx(const void *buf, size_t len, void *c)
+{
+	struct fuzz_ctx *ctx = c;
+	(void)buf;
+	(void)len;
+
+	if (fuzz_chance(ctx, TX_BUSY_CHANCE)) {
+		return -EBUSY;
+	}
+
+	return 0;
+}
+
+static void fuzz_i2c_rxmsg(uint8_t src_eid, bool tag_owner, uint8_t msg_tag,
+			   void *c, void *msg, size_t len)
+{
+	struct fuzz_ctx *ctx = c;
+	(void)ctx;
+	(void)src_eid;
+	(void)tag_owner;
+	(void)msg_tag;
+	(void)msg;
+	(void)len;
+}
+
+static void do_rx(struct fuzz_ctx *ctx)
+{
+	uint32_t len;
+	if (!fuzz_buf_extract_u32(ctx->ctrl, &len)) {
+		ctx->done = true;
+		return;
+	}
+
+	if (len > MAX_RECEIVE) {
+		ctx->done = true;
+		return;
+	}
+
+	const uint8_t *data = fuzz_buf_extract(ctx->input, len);
+	if (!data) {
+		ctx->done = true;
+		return;
+	}
+
+	mctp_i2c_rx(ctx->i2c, data, len);
+}
+
+static void do_tx(struct fuzz_ctx *ctx)
+{
+	int rc;
+
+	const uint8_t *e = fuzz_buf_extract(ctx->ctrl, sizeof(uint8_t));
+	if (!e) {
+		ctx->done = true;
+		return;
+	}
+	mctp_eid_t eid = *e;
+
+	bool tag_owner = fuzz_chance(ctx, 50);
+	/* `t` generates the dest eid in owner case, or tag in non-owner case */
+	const uint8_t *t = fuzz_buf_extract(ctx->ctrl, sizeof(uint8_t));
+	if (!t) {
+		ctx->done = true;
+		return;
+	}
+
+	uint32_t len;
+	if (!fuzz_buf_extract_u32(ctx->ctrl, &len)) {
+		ctx->done = true;
+		return;
+	}
+	len = len % (MAX_SEND + 1);
+
+	uint8_t *fake_send_data = __mctp_msg_alloc(len, ctx->mctp);
+
+	mctp_i2c_tx_poll(ctx->i2c);
+
+	if (tag_owner) {
+		/* Random destination from a small set, reuse `t` */
+		mctp_eid_t dest = 10 + (*t % 5);
+		uint8_t tag;
+		rc = mctp_message_tx_request(ctx->mctp, dest, fake_send_data,
+					     len, &tag);
+		if (rc == 0) {
+			assert((tag & MCTP_HDR_TAG_MASK) == tag);
+		}
+	} else {
+		uint8_t tag = *t % 8;
+		mctp_message_tx_alloced(ctx->mctp, eid, tag_owner, tag,
+					fake_send_data, len);
+	}
+}
+
+static uint64_t fuzz_now(void *c)
+{
+	struct fuzz_ctx *ctx = c;
+
+	uint32_t step = 10;
+	uint32_t s;
+	if (fuzz_buf_extract_u32(ctx->ctrl, &s)) {
+		step = s % (MAX_TIME_STEP + 1);
+	}
+
+	uint64_t prev = ctx->now;
+	ctx->now += step;
+	/* Notice if overflow occurs */
+	assert(ctx->now >= prev);
+	return ctx->now;
+}
+
+int LLVMFuzzerTestOneInput(uint8_t *input, size_t len)
+{
+	/* Split input into two parts. First FUZZCTRL_SIZE (0x400 bytes currently)
+     * is used for fuzzing control (random choices etc).
+     * The remainder is a PLDM packet stream, of length:data */
+	if (len < FUZZCTRL_SIZE) {
+		return 0;
+	}
+
+	struct fuzz_ctx _ctx = {
+		.ctrl = fuzz_buf_new(input, FUZZCTRL_SIZE),
+		.input = fuzz_buf_new(&input[FUZZCTRL_SIZE],
+				      len - FUZZCTRL_SIZE),
+		.now = 0,
+		.done = false,
+	};
+	struct fuzz_ctx *ctx = &_ctx;
+
+	/* Instantiate the MCTP stack */
+	ctx->i2c = malloc(MCTP_SIZEOF_BINDING_I2C);
+	mctp_i2c_setup(ctx->i2c, OWN_I2C_ADDR, fuzz_i2c_tx, ctx);
+	ctx->mctp = mctp_init();
+	mctp_register_bus(ctx->mctp, mctp_binding_i2c_core(ctx->i2c), OWN_EID);
+	mctp_set_rx_all(ctx->mctp, fuzz_i2c_rxmsg, ctx);
+	mctp_set_now_op(ctx->mctp, fuzz_now, ctx);
+
+	while (!ctx->done) {
+		if (fuzz_chance(ctx, RX_CHANCE)) {
+			do_rx(ctx);
+		} else {
+			do_tx(ctx);
+		}
+	}
+
+	mctp_destroy(ctx->mctp);
+	free(ctx->i2c);
+	free(ctx->ctrl);
+	free(ctx->input);
+
+	return 0;
+}
+
+int LLVMFuzzerInitialize(int *argc __unused, char ***argv __unused)
+{
+	return 0;
+}
+
+#ifdef HFND_FUZZING_ENTRY_FUNCTION
+#define USING_HONGGFUZZ 1
+#else
+#define USING_HONGGFUZZ 0
+#endif
+
+#ifdef __AFL_FUZZ_TESTCASE_LEN
+#define USING_AFL 1
+#else
+#define USING_AFL 0
+#endif
+
+#if USING_AFL
+__AFL_FUZZ_INIT();
+#endif
+
+#if !USING_AFL && !USING_HONGGFUZZ
+/* Let it build without AFL taking stdin instead */
+static void run_standalone()
+{
+	while (true) {
+		unsigned char buf[1024000];
+		ssize_t len = read(STDIN_FILENO, buf, sizeof(buf));
+		if (len <= 0) {
+			break;
+		}
+		LLVMFuzzerTestOneInput(buf, len);
+	}
+}
+#endif
+
+#if !USING_HONGGFUZZ
+int main(int argc, char **argv)
+{
+	LLVMFuzzerInitialize(&argc, &argv);
+
+#if USING_AFL
+	__AFL_INIT();
+	uint8_t *buf = __AFL_FUZZ_TESTCASE_BUF;
+
+	while (__AFL_LOOP(100000)) {
+		size_t len = __AFL_FUZZ_TESTCASE_LEN;
+		LLVMFuzzerTestOneInput(buf, len);
+	}
+#else
+	run_standalone();
+#endif
+
+	return 0;
+}
+#endif // !USING_HONGGFUZZ

--- a/tests/fuzz/meson.build
+++ b/tests/fuzz/meson.build
@@ -1,0 +1,10 @@
+if get_option('bindings').contains('i2c')
+    executable(
+        'i2c-fuzz',
+        'i2c-fuzz.c',
+        # for __AFL_LOOP
+        cpp_args: ['-Wno-gnu-statement-expression-from-macro-expansion'],
+        include_directories: test_include_dirs,
+        dependencies: [libmctp_dep],
+        )
+endif

--- a/tests/fuzz/meson.build
+++ b/tests/fuzz/meson.build
@@ -6,5 +6,5 @@ if get_option('bindings').contains('i2c')
         cpp_args: ['-Wno-gnu-statement-expression-from-macro-expansion'],
         include_directories: test_include_dirs,
         dependencies: [libmctp_dep],
-        )
+    )
 endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,28 @@
+
+tests = [
+    'test_eid',
+    'test_seq',
+    'test_bridge',
+    'test_cmds',
+    'test_core',
+    ]
+
+if get_option('bindings').contains('serial')
+    tests += 'test_serial'
+endif
+if get_option('bindings').contains('astlpc')
+    tests += 'test_astlpc'
+endif
+
+test_include_dirs = [include_directories('.'), libmctp_include_dir]
+foreach t : tests
+    test(
+        t,
+        executable(
+            t,
+            [t + '.c', 'test-utils.c'],
+            include_directories: test_include_dirs,
+            dependencies: [libmctp_dep],
+        ),
+    )
+endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,6 +13,9 @@ endif
 if get_option('bindings').contains('astlpc')
     tests += 'test_astlpc'
 endif
+if get_option('bindings').contains('i2c')
+    tests += 'test_i2c'
+endif
 
 test_include_dirs = [include_directories('.'), libmctp_include_dir]
 foreach t : tests

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,11 +1,5 @@
 
-tests = [
-    'test_eid',
-    'test_seq',
-    'test_bridge',
-    'test_cmds',
-    'test_core',
-    ]
+tests = ['test_eid', 'test_seq', 'test_bridge', 'test_cmds', 'test_core']
 
 if get_option('bindings').contains('serial')
     tests += 'test_serial'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -29,3 +29,5 @@ foreach t : tests
         ),
     )
 endforeach
+
+subdir('fuzz')

--- a/tests/test-utils.c
+++ b/tests/test-utils.c
@@ -16,7 +16,7 @@
  * the local EID as the destination */
 struct mctp_binding_test {
 	struct mctp_binding binding;
-	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)];
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)] PKTBUF_STORAGE_ALIGN;
 };
 
 static int mctp_binding_test_tx(struct mctp_binding *b, struct mctp_pktbuf *pkt)

--- a/tests/test-utils.c
+++ b/tests/test-utils.c
@@ -14,6 +14,7 @@
 
 struct mctp_binding_test {
 	struct mctp_binding binding;
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)];
 };
 
 static int mctp_binding_test_tx(struct mctp_binding *b __attribute__((unused)),
@@ -35,6 +36,7 @@ struct mctp_binding_test *mctp_binding_test_init(void)
 	test->binding.pkt_size = MCTP_PACKET_SIZE(MCTP_BTU);
 	test->binding.pkt_header = 0;
 	test->binding.pkt_trailer = 0;
+	test->binding.tx_storage = test->tx_storage;
 	return test;
 }
 
@@ -52,6 +54,7 @@ void mctp_binding_test_rx_raw(struct mctp_binding_test *test, void *buf,
 	assert(pkt);
 	memcpy(mctp_pktbuf_hdr(pkt), buf, len);
 	mctp_bus_rx(&test->binding, pkt);
+	mctp_pktbuf_free(pkt);
 }
 
 void mctp_binding_test_register_bus(struct mctp_binding_test *binding,

--- a/tests/test-utils.c
+++ b/tests/test-utils.c
@@ -12,16 +12,16 @@
 
 #include "test-utils.h"
 
+/* mctp_binding_test can be used for loopback in tests. Senders must use
+ * the local EID as the destination */
 struct mctp_binding_test {
 	struct mctp_binding binding;
 	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)];
 };
 
-static int mctp_binding_test_tx(struct mctp_binding *b __attribute__((unused)),
-				struct mctp_pktbuf *pkt __attribute__((unused)))
+static int mctp_binding_test_tx(struct mctp_binding *b, struct mctp_pktbuf *pkt)
 {
-	/* we are not expecting TX packets */
-	assert(0);
+	mctp_bus_rx(b, pkt);
 	return 0;
 }
 
@@ -73,4 +73,5 @@ void mctp_test_stack_init(struct mctp **mctp,
 	assert(*binding);
 
 	mctp_binding_test_register_bus(*binding, *mctp, eid);
+	mctp_binding_set_tx_enabled(&(*binding)->binding, true);
 }

--- a/tests/test-utils.h
+++ b/tests/test-utils.h
@@ -18,7 +18,7 @@ void mctp_binding_test_register_bus(struct mctp_binding_test *binding,
 void mctp_binding_test_rx_raw(struct mctp_binding_test *test, void *buf,
 			      size_t len);
 
-/* gerneral utility functions */
+/* general utility functions */
 
 /* create a MCTP stack, and add a test binding, using the specified EID */
 void mctp_test_stack_init(struct mctp **mctp,

--- a/tests/test_astlpc.c
+++ b/tests/test_astlpc.c
@@ -1515,20 +1515,13 @@ static const struct {
 };
 /* clang-format on */
 
-#ifndef BUILD_ASSERT
-#define BUILD_ASSERT(x)                                                        \
-	do {                                                                   \
-		(void)sizeof(char[0 - (!(x))]);                                \
-	} while (0)
-#endif
-
 int main(void)
 {
 	size_t i;
 
 	mctp_set_log_stdio(MCTP_LOG_DEBUG);
 
-	BUILD_ASSERT(ARRAY_SIZE(astlpc_tests) < SIZE_MAX);
+	static_assert(ARRAY_SIZE(astlpc_tests) < SIZE_MAX, "size");
 	for (i = 0; i < ARRAY_SIZE(astlpc_tests); i++) {
 		mctp_prlog(MCTP_LOG_DEBUG, "begin: %s", astlpc_tests[i].name);
 		astlpc_tests[i].test();

--- a/tests/test_astlpc.c
+++ b/tests/test_astlpc.c
@@ -736,8 +736,8 @@ static const struct mctp_binding_astlpc astlpc_layout_ctx = {
 static void astlpc_test_buffers_rx_offset_overflow(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { UINT32_MAX, BUFFER_MIN },
-		.tx = { control_size, BUFFER_MIN },
+		.rx = { UINT32_MAX, BUFFER_MIN, buffer_state_idle },
+		.tx = { control_size, BUFFER_MIN, buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -746,8 +746,8 @@ static void astlpc_test_buffers_rx_offset_overflow(void)
 static void astlpc_test_buffers_tx_offset_overflow(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size, BUFFER_MIN },
-		.tx = { UINT32_MAX, BUFFER_MIN },
+		.rx = { control_size, BUFFER_MIN, buffer_state_idle },
+		.tx = { UINT32_MAX, BUFFER_MIN, buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -756,8 +756,9 @@ static void astlpc_test_buffers_tx_offset_overflow(void)
 static void astlpc_test_buffers_rx_size_overflow(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size + BUFFER_MIN, UINT32_MAX },
-		.tx = { control_size, BUFFER_MIN },
+		.rx = { control_size + BUFFER_MIN, UINT32_MAX,
+			buffer_state_idle },
+		.tx = { control_size, BUFFER_MIN, buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -766,8 +767,9 @@ static void astlpc_test_buffers_rx_size_overflow(void)
 static void astlpc_test_buffers_tx_size_overflow(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size, BUFFER_MIN },
-		.tx = { control_size + BUFFER_MIN, UINT32_MAX },
+		.rx = { control_size, BUFFER_MIN, buffer_state_idle },
+		.tx = { control_size + BUFFER_MIN, UINT32_MAX,
+			buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -776,8 +778,9 @@ static void astlpc_test_buffers_tx_size_overflow(void)
 static void astlpc_test_buffers_rx_window_violation(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { LPC_WIN_SIZE - BUFFER_MIN + 1, BUFFER_MIN },
-		.tx = { control_size, BUFFER_MIN },
+		.rx = { LPC_WIN_SIZE - BUFFER_MIN + 1, BUFFER_MIN,
+			buffer_state_idle },
+		.tx = { control_size, BUFFER_MIN, buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -786,8 +789,9 @@ static void astlpc_test_buffers_rx_window_violation(void)
 static void astlpc_test_buffers_tx_window_violation(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size, BUFFER_MIN },
-		.tx = { LPC_WIN_SIZE - BUFFER_MIN + 1, BUFFER_MIN },
+		.rx = { control_size, BUFFER_MIN, buffer_state_idle },
+		.tx = { LPC_WIN_SIZE - BUFFER_MIN + 1, BUFFER_MIN,
+			buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -796,8 +800,9 @@ static void astlpc_test_buffers_tx_window_violation(void)
 static void astlpc_test_buffers_rx_size_fails_btu(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size, BUFFER_MIN - 1 },
-		.tx = { control_size + BUFFER_MIN, BUFFER_MIN },
+		.rx = { control_size, BUFFER_MIN - 1, buffer_state_idle },
+		.tx = { control_size + BUFFER_MIN, BUFFER_MIN,
+			buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -806,8 +811,9 @@ static void astlpc_test_buffers_rx_size_fails_btu(void)
 static void astlpc_test_buffers_tx_size_fails_btu(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size, BUFFER_MIN },
-		.tx = { control_size + BUFFER_MIN, BUFFER_MIN - 1 },
+		.rx = { control_size, BUFFER_MIN, buffer_state_idle },
+		.tx = { control_size + BUFFER_MIN, BUFFER_MIN - 1,
+			buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -816,8 +822,9 @@ static void astlpc_test_buffers_tx_size_fails_btu(void)
 static void astlpc_test_buffers_overlap_rx_low(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size, 2 * BUFFER_MIN },
-		.tx = { control_size + BUFFER_MIN, 2 * BUFFER_MIN },
+		.rx = { control_size, 2 * BUFFER_MIN, buffer_state_idle },
+		.tx = { control_size + BUFFER_MIN, 2 * BUFFER_MIN,
+			buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -826,8 +833,9 @@ static void astlpc_test_buffers_overlap_rx_low(void)
 static void astlpc_test_buffers_overlap_tx_low(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size + BUFFER_MIN, 2 * BUFFER_MIN },
-		.tx = { control_size, 2 * BUFFER_MIN },
+		.rx = { control_size + BUFFER_MIN, 2 * BUFFER_MIN,
+			buffer_state_idle },
+		.tx = { control_size, 2 * BUFFER_MIN, buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -836,8 +844,8 @@ static void astlpc_test_buffers_overlap_tx_low(void)
 static void astlpc_test_buffers_overlap_exact(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { control_size, 2 * BUFFER_MIN },
-		.tx = { control_size, 2 * BUFFER_MIN },
+		.rx = { control_size, 2 * BUFFER_MIN, buffer_state_idle },
+		.tx = { control_size, 2 * BUFFER_MIN, buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));
@@ -846,8 +854,9 @@ static void astlpc_test_buffers_overlap_exact(void)
 static void astlpc_test_buffers_overlap_control(void)
 {
 	struct mctp_astlpc_layout l = {
-		.rx = { 0, BUFFER_MIN },
-		.tx = { control_size + BUFFER_MIN, BUFFER_MIN },
+		.rx = { 0, BUFFER_MIN, buffer_state_idle },
+		.tx = { control_size + BUFFER_MIN, BUFFER_MIN,
+			buffer_state_idle },
 	};
 
 	assert(!mctp_astlpc_layout_validate(&astlpc_layout_ctx, &l));

--- a/tests/test_bridge.c
+++ b/tests/test_bridge.c
@@ -19,6 +19,7 @@ struct mctp_binding_bridge {
 	int rx_count;
 	int tx_count;
 	uint8_t last_pkt_data;
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)];
 };
 
 struct test_ctx {
@@ -61,6 +62,7 @@ static void mctp_binding_bridge_rx(struct mctp_binding_bridge *binding,
 
 	binding->rx_count++;
 	mctp_bus_rx(&binding->binding, pkt);
+	mctp_pktbuf_free(pkt);
 }
 
 static struct mctp_binding_bridge *mctp_binding_bridge_init(char *name)
@@ -75,6 +77,7 @@ static struct mctp_binding_bridge *mctp_binding_bridge_init(char *name)
 	binding->binding.pkt_size = MCTP_PACKET_SIZE(MCTP_BTU);
 	binding->binding.pkt_header = 0;
 	binding->binding.pkt_trailer = 0;
+	binding->binding.tx_storage = binding->tx_storage;
 	return binding;
 }
 

--- a/tests/test_bridge.c
+++ b/tests/test_bridge.c
@@ -19,7 +19,7 @@ struct mctp_binding_bridge {
 	int rx_count;
 	int tx_count;
 	uint8_t last_pkt_data;
-	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)];
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)] PKTBUF_STORAGE_ALIGN;
 };
 
 struct test_ctx {

--- a/tests/test_cmds.c
+++ b/tests/test_cmds.c
@@ -50,6 +50,7 @@ static void rcv_ctrl_msg(struct mctp_binding *b, const void *buf, size_t len)
 	struct mctp_pktbuf *pkt = mctp_pktbuf_alloc(b, len);
 	memcpy(mctp_pktbuf_hdr(pkt), buf, len);
 	mctp_bus_rx(b, pkt);
+	mctp_pktbuf_free(pkt);
 }
 
 static void setup_test_binding(struct mctp_binding *test_binding,
@@ -59,6 +60,7 @@ static void setup_test_binding(struct mctp_binding *test_binding,
 	assert(test_endpoint != NULL);
 	assert(callback_ctx != NULL);
 
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)];
 	memset(test_binding, 0, sizeof(*test_binding));
 	test_binding->name = "test";
 	test_binding->version = 1;
@@ -68,6 +70,7 @@ static void setup_test_binding(struct mctp_binding *test_binding,
 	test_binding->pkt_trailer = 0;
 	test_binding->control_rx = control_message_transport_callback;
 	test_binding->control_rx_data = callback_ctx;
+	test_binding->tx_storage = tx_storage;
 
 	mctp_register_bus(test_endpoint, test_binding, eid_1);
 	mctp_binding_set_tx_enabled(test_binding, true);

--- a/tests/test_cmds.c
+++ b/tests/test_cmds.c
@@ -60,7 +60,7 @@ static void setup_test_binding(struct mctp_binding *test_binding,
 	assert(test_endpoint != NULL);
 	assert(callback_ctx != NULL);
 
-	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)];
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_BTU)] PKTBUF_STORAGE_ALIGN;
 	memset(test_binding, 0, sizeof(*test_binding));
 	test_binding->name = "test";
 	test_binding->version = 1;

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -97,11 +97,11 @@ static void receive_ptkbuf(struct mctp_binding_test *binding,
 	rx_pkt->start = 0;
 	rx_pkt->end = MCTP_PACKET_SIZE(len);
 	rx_pkt->mctp_hdr_off = 0;
-	rx_pkt->next = NULL;
 	memcpy(rx_pkt->data, &pktbuf->hdr, sizeof(pktbuf->hdr));
 	memcpy(rx_pkt->data + sizeof(pktbuf->hdr), pktbuf->payload, alloc_size);
 
 	mctp_bus_rx((struct mctp_binding *)binding, rx_pkt);
+	__mctp_free(rx_pkt);
 }
 
 static void receive_one_fragment(struct mctp_binding_test *binding,

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -623,20 +623,13 @@ static const struct {
 };
 /* clang-format on */
 
-#ifndef BUILD_ASSERT
-#define BUILD_ASSERT(x)                                                        \
-	do {                                                                   \
-		(void)sizeof(char[0 - (!(x))]);                                \
-	} while (0)
-#endif
-
 int main(void)
 {
 	uint8_t i;
 
 	mctp_set_log_stdio(MCTP_LOG_DEBUG);
 
-	BUILD_ASSERT(ARRAY_SIZE(mctp_core_tests) < SIZE_MAX);
+	static_assert(ARRAY_SIZE(mctp_core_tests) < SIZE_MAX, "size");
 	for (i = 0; i < ARRAY_SIZE(mctp_core_tests); i++) {
 		mctp_prlog(MCTP_LOG_DEBUG, "begin: %s",
 			   mctp_core_tests[i].name);

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -31,7 +31,7 @@
 #define TEST_SRC_EID		10
 
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #endif
 
 #define MAX_PAYLOAD_SIZE 50000

--- a/tests/test_core.c
+++ b/tests/test_core.c
@@ -470,7 +470,7 @@ static void mctp_core_test_rx_with_tag()
 	pktbuf.hdr.dest = TEST_DEST_EID;
 	pktbuf.hdr.src = TEST_SRC_EID;
 
-	/* Set tag and tag owner fields for a recieve packet */
+	/* Set tag and tag owner fields for a receive packet */
 	flags_seq_tag = MCTP_HDR_FLAG_SOM | MCTP_HDR_FLAG_EOM |
 			(1 << MCTP_HDR_TO_SHIFT) | tag;
 	receive_one_fragment(binding, test_payload, MCTP_BTU, flags_seq_tag,

--- a/tests/test_i2c.c
+++ b/tests/test_i2c.c
@@ -259,5 +259,10 @@ int main(void)
 
 	test_neigh_expiry(tx_test, rx_test);
 
+	free(tx_test->i2c);
+	free(rx_test->i2c);
+	mctp_destroy(tx_test->mctp);
+	mctp_destroy(rx_test->mctp);
+
 	return 0;
 }

--- a/tests/test_i2c.c
+++ b/tests/test_i2c.c
@@ -1,0 +1,263 @@
+/* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "compiler.h"
+#include "range.h"
+#include "libmctp-log.h"
+#include "libmctp-i2c.h"
+#include "libmctp-sizes.h"
+#include "libmctp-alloc.h"
+
+/* For access to mctp_bninding_i2c internals */
+#include "i2c-internal.h"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+struct mctp_binding_serial_pipe {
+	int ingress;
+	int egress;
+
+	struct mctp_binding_serial *serial;
+};
+
+// Sized to test fragmentation and >8 bit length
+#define TEST_MSG_LEN 300
+static uint8_t mctp_msg_src[TEST_MSG_LEN];
+
+struct i2c_test {
+	struct mctp_binding_i2c *i2c;
+	struct mctp *mctp;
+
+	uint8_t rx_msg[TEST_MSG_LEN];
+	size_t rx_len;
+
+	/* Physical addresses. These get set regardless of whether the packet
+	 * is dropped by the stack (no match etc) */
+	uint8_t last_rx_i2c_src;
+	uint8_t last_tx_i2c_dst;
+};
+
+static const uint8_t I2C_ADDR_A = 0x20;
+static const uint8_t I2C_ADDR_B = 0x21;
+static const uint8_t EID_A = 50;
+static const uint8_t EID_B = 51;
+
+static int test_i2c_tx(const void *buf, size_t len, void *ctx)
+{
+	struct i2c_test *test_pair = ctx;
+	struct i2c_test *tx_test = &test_pair[0];
+	struct i2c_test *rx_test = &test_pair[1];
+
+	mctp_prdebug("test_i2c_tx len %zu", len);
+
+	const struct mctp_i2c_hdr *hdr = buf;
+	tx_test->last_tx_i2c_dst = hdr->dest >> 1;
+	rx_test->last_rx_i2c_src = hdr->source >> 1;
+
+	mctp_i2c_rx(rx_test->i2c, buf, len);
+	return 0;
+}
+
+static void test_i2c_rxmsg(uint8_t src_eid, bool tag_owner, uint8_t msg_tag,
+			   void *ctx, void *msg, size_t len)
+{
+	struct i2c_test *test_pair = ctx;
+	// struct i2c_test *tx_test = &test_pair[0];
+	struct i2c_test *rx_test = &test_pair[1];
+
+	mctp_prdebug("test_i2c_rx src %d len %zu tag %d owner %d", src_eid, len,
+		     msg_tag, tag_owner);
+
+	// Must be cleared by previous test runs
+	assert(rx_test->rx_len == 0);
+	memcpy(rx_test->rx_msg, msg, len);
+	rx_test->rx_len = len;
+}
+
+/* Transmits a MCTP message and checks the received message matches */
+static void run_tx_test(struct i2c_test *tx_test, uint8_t dest_eid,
+			size_t tx_len, struct i2c_test *rx_test)
+{
+	int rc;
+	const uint8_t msg_tag = 2;
+	const bool tag_owner = false;
+
+	assert(tx_len <= sizeof(mctp_msg_src));
+	rc = mctp_message_tx(tx_test->mctp, dest_eid, tag_owner, msg_tag,
+			     mctp_msg_src, tx_len);
+	assert(rc == 0);
+
+	while (!mctp_is_tx_ready(tx_test->mctp, dest_eid)) {
+		mctp_i2c_tx_poll(tx_test->i2c);
+	}
+
+	assert(rx_test->rx_len == tx_len);
+	assert(memcmp(rx_test->rx_msg, mctp_msg_src, tx_len) == 0);
+
+	rx_test->rx_len = 0;
+}
+
+static void test_neigh_expiry(struct i2c_test *tx_test,
+			      struct i2c_test *rx_test)
+{
+	const uint8_t msg_tag = 2;
+	const bool tag_owner = true;
+	const size_t msg_len = 5;
+	int rc;
+
+	(void)rx_test;
+
+	/* Clear the tx neighbour table */
+	memset(tx_test->i2c->neigh, 0x0, sizeof(tx_test->i2c->neigh));
+
+	/* Check that all EIDs fail */
+	rx_test->rx_len = 0;
+	for (size_t eid = 8; eid < 254; eid++) {
+		mctp_message_tx(tx_test->mctp, eid, tag_owner, msg_tag,
+				mctp_msg_src, msg_len);
+		/* Not received */
+		assert(rx_test->rx_len == 0);
+	}
+
+	/* Add one entry */
+	rc = mctp_i2c_set_neighbour(tx_test->i2c, EID_B,
+				    rx_test->i2c->own_addr);
+	assert(rc == 0);
+	rx_test->rx_len = 0;
+	mctp_message_tx(tx_test->mctp, EID_B, tag_owner, msg_tag, mctp_msg_src,
+			msg_len);
+	assert(rx_test->rx_len == msg_len);
+	assert(tx_test->last_tx_i2c_dst == rx_test->i2c->own_addr);
+
+	/* Replace the entry */
+	rx_test->i2c->own_addr++;
+	rc = mctp_i2c_set_neighbour(tx_test->i2c, EID_B,
+				    rx_test->i2c->own_addr);
+	assert(rc == 0);
+	rx_test->rx_len = 0;
+	mctp_message_tx(tx_test->mctp, EID_B, tag_owner, msg_tag, mctp_msg_src,
+			msg_len);
+	assert(rc == 0);
+	assert(rx_test->rx_len == msg_len);
+	assert(tx_test->last_tx_i2c_dst == rx_test->i2c->own_addr);
+
+	/* Check only one entry is set */
+	size_t count = 0;
+	for (size_t i = 0; i < MCTP_I2C_NEIGH_COUNT; i++) {
+		struct mctp_i2c_neigh *n = &tx_test->i2c->neigh[i];
+		if (n->used) {
+			assert(n->eid == EID_B);
+			count++;
+		}
+	}
+	assert(count == 1);
+
+	/* Ensure we can iterate without overflow.
+	 * If MCTP_I2C_NEIGH_COUNT increases too large this test would need rethinking
+	 * (and eviction may become impossible) */
+	assert((int)EID_B + MCTP_I2C_NEIGH_COUNT < 254);
+	assert((int)I2C_ADDR_B + MCTP_I2C_NEIGH_COUNT < 0x7f);
+
+	/* Fill entries. -1 because one was already filled. */
+	for (size_t i = 0; i < MCTP_I2C_NEIGH_COUNT - 1; i++) {
+		/* Unused addresses */
+		uint8_t addr = rx_test->i2c->own_addr + i + 1;
+		uint8_t eid = EID_B + i + 1;
+		rc = mctp_i2c_set_neighbour(tx_test->i2c, eid, addr);
+		assert(rc == 0);
+	}
+
+	/* Check all are used */
+	for (size_t i = 0; i < MCTP_I2C_NEIGH_COUNT; i++) {
+		struct mctp_i2c_neigh *n = &tx_test->i2c->neigh[i];
+		assert(n->used);
+	}
+
+	/* Test eviction */
+	{
+		uint8_t addr =
+			rx_test->i2c->own_addr + MCTP_I2C_NEIGH_COUNT + 1;
+		uint8_t eid = EID_B + MCTP_I2C_NEIGH_COUNT + 1;
+		rc = mctp_i2c_set_neighbour(tx_test->i2c, eid, addr);
+		assert(rc == 0);
+
+		/* EID_B got evicted, send should fail */
+		rx_test->rx_len = 0;
+		mctp_message_tx(tx_test->mctp, EID_B, tag_owner, msg_tag,
+				mctp_msg_src, msg_len);
+		/* Not received */
+		assert(rx_test->rx_len == 0);
+	}
+
+	/* Add EID_B again */
+	rc = mctp_i2c_set_neighbour(tx_test->i2c, EID_B,
+				    rx_test->i2c->own_addr);
+	assert(rc == 0);
+	rx_test->rx_len = 0;
+	mctp_message_tx(tx_test->mctp, EID_B, tag_owner, msg_tag, mctp_msg_src,
+			msg_len);
+	/* Is received */
+	assert(rx_test->rx_len == msg_len);
+}
+
+int main(void)
+{
+	struct i2c_test scenario[2];
+	struct i2c_test *tx_test = &scenario[0];
+	struct i2c_test *rx_test = &scenario[1];
+
+	mctp_set_log_stdio(MCTP_LOG_DEBUG);
+
+	memset(scenario, 0x0, sizeof(scenario));
+
+	/* Setup a source buffer */
+	for (size_t i = 0; i < sizeof(mctp_msg_src); i++) {
+		mctp_msg_src[i] = i & 0xff;
+	}
+
+	tx_test->mctp = mctp_init();
+	assert(tx_test->mctp);
+	tx_test->i2c = malloc(MCTP_SIZEOF_BINDING_I2C);
+	assert(tx_test->i2c);
+	rx_test->mctp = mctp_init();
+	assert(rx_test->mctp);
+	rx_test->i2c = malloc(MCTP_SIZEOF_BINDING_I2C);
+	assert(rx_test->i2c);
+
+	/* TX side */
+	mctp_i2c_setup(tx_test->i2c, I2C_ADDR_A, test_i2c_tx, scenario);
+	mctp_register_bus(tx_test->mctp, mctp_binding_i2c_core(tx_test->i2c),
+			  EID_A);
+	mctp_set_rx_all(tx_test->mctp, NULL, NULL);
+	mctp_i2c_set_neighbour(tx_test->i2c, EID_B, I2C_ADDR_B);
+
+	/* RX side */
+	mctp_i2c_setup(rx_test->i2c, I2C_ADDR_B, NULL, NULL);
+	mctp_register_bus(rx_test->mctp, mctp_binding_i2c_core(rx_test->i2c),
+			  EID_B);
+	mctp_set_rx_all(rx_test->mctp, test_i2c_rxmsg, scenario);
+	// mctp_i2c_set_neighbour(rx_test->i2c, EID_A, I2C_ADDR_A);
+
+	/* Try all message sizes */
+	for (size_t i = 1; i < sizeof(mctp_msg_src); i++) {
+		run_tx_test(tx_test, EID_B, i, rx_test);
+	}
+
+	test_neigh_expiry(tx_test, rx_test);
+
+	return 0;
+}

--- a/tests/test_seq.c
+++ b/tests/test_seq.c
@@ -14,7 +14,7 @@
 #include "test-utils.h"
 
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #endif
 
 struct test_ctx {
@@ -40,7 +40,7 @@ static void test_rx(uint8_t eid __unused, bool tag_owner __unused,
 	ctx->rx_len += len;
 }
 
-#define SEQ(x) (x << MCTP_HDR_SEQ_SHIFT)
+#define SEQ(x) ((x) << MCTP_HDR_SEQ_SHIFT)
 
 struct test {
 	int n_packets;

--- a/tests/test_serial.c
+++ b/tests/test_serial.c
@@ -91,10 +91,10 @@ int main(void)
 	 * to escape sequence 0x7d 0x5e / 0x7d 0x5d.
 	 *
 	 * For sender, FCS calculation should count data byte (0x7e / 0x7d) only,
-	 * not the escape sequece. For receiver, the escape sequence should be
+	 * not the escape sequence. For receiver, the escape sequence should be
 	 * translated back to data byte and put it in FCS calculation.
 	 *
-	 * If FCS calculation is not expected, similiar error msg
+	 * If FCS calculation is not expected, similar error msg
 	 * `serial: invalid fcs : 0xf5c1, expect 0x1d3e` will be observed.
 	 */
 	memset(&mctp_msg_src[0], 0x7e, 1);

--- a/utils/mctp-capture.c
+++ b/utils/mctp-capture.c
@@ -30,8 +30,6 @@ int capture_init(void)
 
 int capture_prepare(struct capture *cap)
 {
-	int rc;
-
 	if (!(cap->pcap = pcap_open_dead(CAPTURE_LINKTYPE_LINUX_SLL2,
 					 UINT16_MAX))) {
 		fprintf(stderr, "pcap_open_dead: failed\n");
@@ -135,7 +133,7 @@ void capture_socket(pcap_dumper_t *dumper, const void *buf, size_t len,
 
 	/* Ignore the eid at start of buf */
 	memcpy(pktbuf + sizeof(struct sll2_header) + sizeof(struct mctp_hdr),
-	       buf + 1, len - 1);
+	       (const uint8_t *)buf + 1, len - 1);
 
 	hdr.caplen = size;
 	hdr.len = size;

--- a/utils/mctp-capture.h
+++ b/utils/mctp-capture.h
@@ -3,7 +3,9 @@
 #ifndef _UTILS_MCTP_CAPTURE_H
 #define _UTILS_MCTP_CAPTURE_H
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 
 #include "compiler.h"
 #include "libmctp.h"

--- a/utils/mctp-demux-daemon.c
+++ b/utils/mctp-demux-daemon.c
@@ -2,7 +2,9 @@
 
 #define _GNU_SOURCE
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 
 #define SD_LISTEN_FDS_START 3
 
@@ -64,7 +66,7 @@ struct ctx {
 	struct binding *binding;
 	bool verbose;
 	int local_eid;
-	void *buf;
+	uint8_t *buf;
 	size_t buf_size;
 
 	int sock;

--- a/utils/mctp-demux-daemon.c
+++ b/utils/mctp-demux-daemon.c
@@ -613,7 +613,7 @@ int main(int argc, char *const *argv)
 	ctx->pcap.socket.path = NULL;
 
 	for (;;) {
-		rc = getopt_long(argc, argv, "b:es::v", options, NULL);
+		rc = getopt_long(argc, argv, "b:e:s::v", options, NULL);
 		if (rc == -1)
 			break;
 		switch (rc) {

--- a/utils/mctp-demux-daemon.c
+++ b/utils/mctp-demux-daemon.c
@@ -31,7 +31,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 #if HAVE_SYSTEMD_SD_DAEMON_H
 #include <systemd/sd-daemon.h>

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -1,0 +1,32 @@
+demux_sources = ['mctp-demux-daemon.c']
+demux_args = []
+demux_dep = [libmctp_dep, pcap_dep, libsystemd_dep]
+# While mctp-demux-daemon will build without pcap, it won't
+# be functional.
+# TODO only build mctp-demux-daemon when pcap is available.
+if pcap_dep.found()
+    demux_args += '-DHAVE_PCAP'
+    demux_sources += 'mctp-capture.c'
+endif
+
+demux = executable('mctp-demux-daemon',
+    demux_sources,
+    include_directories: libmctp_include_dir,
+    dependencies: demux_dep,
+    c_args: demux_args,
+    install: true,
+)
+
+pipe = executable('mctp-pipe',
+    'mctp-pipe.c',
+    include_directories: libmctp_include_dir,
+    dependencies: [libmctp_dep],
+    install: false,
+)
+
+mctp_in = executable('mctp-in',
+    'mctp-in.c',
+    include_directories: libmctp_include_dir,
+    dependencies: [libmctp_dep],
+    install: false,
+)

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -9,7 +9,8 @@ if pcap_dep.found()
     demux_sources += 'mctp-capture.c'
 endif
 
-demux = executable('mctp-demux-daemon',
+demux = executable(
+    'mctp-demux-daemon',
     demux_sources,
     include_directories: libmctp_include_dir,
     dependencies: demux_dep,
@@ -17,14 +18,16 @@ demux = executable('mctp-demux-daemon',
     install: true,
 )
 
-pipe = executable('mctp-pipe',
+pipe = executable(
+    'mctp-pipe',
     'mctp-pipe.c',
     include_directories: libmctp_include_dir,
     dependencies: [libmctp_dep],
     install: false,
 )
 
-mctp_in = executable('mctp-in',
+mctp_in = executable(
+    'mctp-in',
     'mctp-in.c',
     include_directories: libmctp_include_dir,
     dependencies: [libmctp_dep],

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,22 +1,24 @@
 # Copyright (c) 2024 Intel Corporation.
+# Copyright (c) 2025 The Linux Foundation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-set(MCTP_SRC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+if(CONFIG_MCTP)
+  set(MCTP_SRC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-zephyr_interface_library_named(mctp)
-target_link_libraries(zephyr_interface INTERFACE mctp)
-target_include_directories(mctp INTERFACE ${MCTP_SRC})
+  zephyr_interface_library_named(mctp)
+  target_link_libraries(zephyr_interface INTERFACE mctp)
+  target_include_directories(mctp INTERFACE ${MCTP_SRC})
 
-zephyr_library_named(modules_mctp)
-zephyr_library_link_libraries(mctp)
+  zephyr_library_named(modules_mctp)
+  zephyr_library_link_libraries(mctp)
 
-zephyr_library_sources_ifdef(
-	CONFIG_MCTP
-	${MCTP_SRC}/alloc.c
-	${MCTP_SRC}/crc32.c
-	${MCTP_SRC}/core.c
-	${MCTP_SRC}/log.c
-	${MCTP_SRC}/libmctp.h
-	${MCTP_SRC}/crc-16-ccitt.c
-)
+  zephyr_library_sources(
+    ${MCTP_SRC}/alloc.c
+    ${MCTP_SRC}/crc32.c
+    ${MCTP_SRC}/core.c
+    ${MCTP_SRC}/log.c
+    ${MCTP_SRC}/libmctp.h
+    ${MCTP_SRC}/crc-16-ccitt.c
+  )
+endif()

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set(MCTP_SRC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+zephyr_interface_library_named(mctp)
+target_link_libraries(zephyr_interface INTERFACE mctp)
+target_include_directories(mctp INTERFACE ${MCTP_SRC})
+
+zephyr_library_named(modules_mctp)
+zephyr_library_link_libraries(mctp)
+
+zephyr_library_sources_ifdef(
+	CONFIG_MCTP
+	${MCTP_SRC}/alloc.c
+	${MCTP_SRC}/crc32.c
+	${MCTP_SRC}/core.c
+	${MCTP_SRC}/log.c
+	${MCTP_SRC}/libmctp.h
+	${MCTP_SRC}/crc-16-ccitt.c
+)

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -15,6 +15,7 @@ if(CONFIG_MCTP)
 
   zephyr_library_sources(
     ${MCTP_SRC}/alloc.c
+    ${MCTP_SRC}/control.c
     ${MCTP_SRC}/crc32.c
     ${MCTP_SRC}/core.c
     ${MCTP_SRC}/log.c

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -13,6 +13,10 @@ if(CONFIG_MCTP)
   zephyr_library_named(modules_mctp)
   zephyr_library_link_libraries(mctp)
 
+  zephyr_library_compile_definitions(
+    MCTP_MAX_MESSAGE_SIZE=${CONFIG_MCTP_MAX_MESSAGE_SIZE}
+  )
+
   zephyr_library_sources(
     ${MCTP_SRC}/alloc.c
     ${MCTP_SRC}/control.c

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+name: libmctp
+build:
+  cmake: zephyr


### PR DESCRIPTION
Update to a more recent version of libmctp. Since previous "version", libmctp evolved:

 - Support for MCTP Control Messages;
 - Message pools - so allocation can be avoided;
 - Bindings for I2C;
 - Assorted fixes.

The companion PR on Zephyr is https://github.com/zephyrproject-rtos/zephyr/pull/107213
